### PR TITLE
fix(calendar): let hosts save non-airbnb/booking platform links

### DIFF
--- a/src/app/api/calendar/links/route.ts
+++ b/src/app/api/calendar/links/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { logAudit } from "@/lib/audit";
 import { canManageProperty } from "@/lib/ownership";
+import { isValidPlatformSlug } from "@/lib/platforms";
 
 // GET /api/calendar/links?propertyId=1
 export async function GET(request: NextRequest) {
@@ -59,9 +60,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!["airbnb", "booking"].includes(platform)) {
+    // Any slug the platform registry considers canonical is allowed here.
+    // The onboarding wizard already persists arbitrary platforms, the feed
+    // route resolves `for-<slug>.ics` for arbitrary slugs, and PLATFORM_PRESETS
+    // ships twelve of them — this route was the only place still pinned to
+    // the original airbnb/booking pair, so hosts on Vrbo, Expedia, Agoda or a
+    // custom source could not save a link after signup.
+    if (typeof platform !== "string" || !isValidPlatformSlug(platform)) {
       return NextResponse.json(
-        { error: "platform must be 'airbnb' or 'booking'" },
+        { error: "platform must be a valid slug: lower-case a-z, 0-9 and dashes, 1-32 chars" },
         { status: 400 }
       );
     }

--- a/src/components/sync-settings.tsx
+++ b/src/components/sync-settings.tsx
@@ -365,22 +365,41 @@ export function SyncSettings({ propertyId, propertyName, properties, minNights, 
 
   const getLink = (platform: string) => links.find((l) => l.platform === platform);
 
-  const handleSave = async (platform: string, url: string) => {
-    if (!url.trim()) return;
+  // Returns whether the link was actually persisted. The caller uses this to
+  // decide if a draft row may be dropped — previously the POST result was
+  // ignored, so a rejected save still removed the row and the platform
+  // vanished from the page with no error anywhere.
+  const handleSave = async (platform: string, url: string): Promise<boolean> => {
+    if (!url.trim()) return false;
     const link = getLink(platform);
-    await fetch("/api/calendar/links", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        propertyId,
-        platform,
-        icalExportUrl: url.trim(),
-        bufferBefore: link?.bufferBefore ?? 0,
-        bufferAfter: link?.bufferAfter ?? 0,
-      }),
-    });
+    try {
+      const res = await fetch("/api/calendar/links", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          propertyId,
+          platform,
+          icalExportUrl: url.trim(),
+          bufferBefore: link?.bufferBefore ?? 0,
+          bufferAfter: link?.bufferAfter ?? 0,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        // Reuse the Test result box so the reason lands next to the input.
+        setTestResults((prev) => ({
+          ...prev,
+          [platform]: { success: false, error: body?.error || `Save failed (HTTP ${res.status})` },
+        }));
+        return false;
+      }
+    } catch (err) {
+      setTestResults((prev) => ({ ...prev, [platform]: { success: false, error: String(err) } }));
+      return false;
+    }
     setEditingPlatform(null);
     await fetchData();
+    return true;
   };
 
   const handleDelete = async (platform: string) => {
@@ -807,10 +826,12 @@ export function SyncSettings({ propertyId, propertyName, properties, minNights, 
                       </button>
                       <button
                         onClick={async () => {
-                          await handleSave(platform, url);
+                          const saved = await handleSave(platform, url);
                           // For drafts: drop the draft row once persisted —
-                          // it'll re-render via the customLinks branch.
-                          if (isDraft) removeCustomDraft(rowId);
+                          // it'll re-render via the customLinks branch. On a
+                          // rejected save keep the row so the host can read
+                          // the error and correct the input.
+                          if (saved && isDraft) removeCustomDraft(rowId);
                         }}
                         disabled={!url.trim() || (isDraft && !draftRow?.displayName.trim())}
                         className="rounded-md bg-[var(--m-accent)] px-2.5 py-1 text-xs font-medium text-white hover:bg-[var(--m-accent-2)] disabled:opacity-40"

--- a/src/lib/feed-utils.test.ts
+++ b/src/lib/feed-utils.test.ts
@@ -27,6 +27,15 @@ describe("parseFeedFilename", () => {
     expect(parseFeedFilename("for-platform99.ics")).toBe("platform99");
   });
 
+  it("accepts dashed slugs", () => {
+    // isValidPlatformSlug() allows dashes, so a host can create the platform
+    // `my-cottage` and then be handed /for-my-cottage.ics as its feed URL.
+    // Falling back to "airbnb" here would serve that destination the Airbnb
+    // feed, which omits Airbnb stays — dates would silently look free.
+    expect(parseFeedFilename("for-my-cottage.ics")).toBe("my-cottage");
+    expect(parseFeedFilename("for-plum-guide.ics")).toBe("plum-guide");
+  });
+
   it("matches case-insensitively", () => {
     expect(parseFeedFilename("FOR-Vrbo.ICS")).toBe("Vrbo");
   });

--- a/src/lib/feed-utils.ts
+++ b/src/lib/feed-utils.ts
@@ -11,6 +11,11 @@
  * requests rather than 400'ing.
  */
 export function parseFeedFilename(filename: string): string {
-  const match = filename.match(/^for-(\w+)\.ics$/i);
+  // `-` is part of the canonical slug shape (see SLUG_RE in lib/platforms),
+  // but `\w` excludes it, so a dashed slug such as `my-cottage` used to fall
+  // through to the "airbnb" default. That is worse than a 404: the caller
+  // then serves the Airbnb feed, which deliberately omits Airbnb stays, so
+  // the destination silently receives a calendar with bookings missing.
+  const match = filename.match(/^for-([\w-]+)\.ics$/i);
   return match?.[1] || "airbnb";
 }


### PR DESCRIPTION
## Problem

`POST /api/calendar/links` still validates `platform` against the original pair:

```ts
if (!["airbnb", "booking"].includes(platform)) {
  return NextResponse.json({ error: "platform must be 'airbnb' or 'booking'" }, { status: 400 });
}
```

Everything around it has already moved past that:

- `PLATFORM_PRESETS` ships twelve platforms (vrbo, expedia, hostaway, lodgify, …)
- `claimOnboardingDraft()` persists whatever slug the wizard collected, with no allowlist
- `parseFeedFilename()` resolves `for-<slug>.ics` for any slug — its test file says so directly: *"The whole point of this parser is that it accepts ANY platform slug, not just airbnb/booking."*
- `sync-settings` renders a Vrbo card and an "Add another platform" button

So the UI invites a host to add Vrbo, Expedia, Agoda or a custom source, and the API answers 400. A link added during onboarding works; the same link added afterwards cannot be saved.

## Why it is hard to notice

`handleSave()` ignored the response, and the Save button dropped the draft row unconditionally right after:

```ts
await handleSave(platform, url);
if (isDraft) removeCustomDraft(rowId);
```

so the row just vanished — no error toast, nothing in the console.

Reproduced on renttools.io: **Add another platform** → name it → paste an iCal URL → **Test** reports `1 upcoming · 1 total events` → **Save** → reload → the row is gone. The Test passing is what makes this so confusing: the URL is fine, the write is what fails.

## Changes

1. **`src/app/api/calendar/links/route.ts`** — validate with the existing `isValidPlatformSlug()` instead of the hardcoded pair, so the route agrees with the platform registry.

2. **`src/lib/feed-utils.ts`** — `parseFeedFilename()` accepts `-`. `SLUG_RE` in `lib/platforms` allows dashes and its comment describes the slug as a `for-{slug}.ics` path component, but `\w` excludes `-`, so a dashed slug fell through to the `"airbnb"` default. That is worse than a 404: the airbnb target deliberately omits Airbnb stays, so the destination receives a calendar with bookings *missing* rather than an error. Without this, change 1 would let hosts save a dashed slug that can never be targeted.

3. **`src/components/sync-settings.tsx`** — `handleSave()` returns whether the POST succeeded, surfaces the server error in the existing Test result box, and the draft row is kept when the save was rejected.

## Testing

- `npm test` — **188 passed (12 files)**, including two new `parseFeedFilename` cases for dashed slugs
- `npx tsc --noEmit` — clean
- `npm run lint` crashes loading `react/display-name` on this eslint 10 / eslint-plugin-react combination. It fails identically on a clean `master` checkout, so it is unrelated to this change.

## Notes

Happy to split this into three PRs if you would rather review them separately — I kept them together because change 1 is unsafe without change 2, and change 3 is what makes the failure visible at all.

Found while connecting a self-hosted availability feed as a custom source; the same wall blocks Agoda, whose iCal export works fine as an inbound source once a link can be saved.
