### PR TITLE
feat: secure unified guest pre-check-in flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 # Generate with: openssl rand -hex 32
 JWT_SECRET=replace-with-strong-random-32-byte-hex-string
 
+# Encrypts pre-check-in identity data and issued guest-form tokens at rest.
+# Required before any unified guest link can be generated. Generate a distinct
+# value with: openssl rand -hex 32
+GUEST_DATA_ENCRYPTION_KEY=replace-with-distinct-random-32-byte-hex-string
+
 # === Cron ===
 # Used by /api/calendar/cron — only requests with ?secret=<this> are accepted
 # (or Authorization: Bearer <this>). Generate the same way as JWT_SECRET.

--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,21 @@
 # === Auth ===
 # Generate with: openssl rand -hex 32
 JWT_SECRET=replace-with-strong-random-32-byte-hex-string
+# Canonical HTTPS origin used for same-origin checks on public pre-check-in
+# writes. Required in production; never inferred from forwarded Host headers.
+PUBLIC_APP_URL=https://renttools.io
 
 # Encrypts pre-check-in identity data and issued guest-form tokens at rest.
 # Required before any unified guest link can be generated. Generate a distinct
 # value with: openssl rand -hex 32
 GUEST_DATA_ENCRYPTION_KEY=replace-with-distinct-random-32-byte-hex-string
+# Version written into every new ciphertext. Increment this when rotating the
+# current key; keep earlier keys in the JSON map below until all old data has
+# been re-encrypted or expired.
+GUEST_DATA_ENCRYPTION_KEY_VERSION=v1
+# Example after rotating to v2:
+# GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS={"v1":"old-64-character-hex-key"}
+GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS=
 
 # === Cron ===
 # Used by /api/calendar/cron — only requests with ?secret=<this> are accepted
@@ -16,8 +26,18 @@ GUEST_DATA_ENCRYPTION_KEY=replace-with-distinct-random-32-byte-hex-string
 CRON_SECRET=replace-with-strong-random-32-byte-hex-string
 
 # === AI / passport extraction ===
+# Fail-closed legacy feature gate. Leave false until uploaded documents and
+# extracted plaintext fields have a proven deletion/retention lifecycle.
+NEXT_PUBLIC_LEGACY_PASSPORT_OCR_ENABLED=false
 # Get a free key at https://aistudio.google.com
 GOOGLE_GEMINI_API_KEY=
+
+# === eVisitor test integration (disabled until synthetic E2E approval) ===
+# Load these from the deployment secret manager. Never commit real values.
+# The adapter currently rejects the production API by design.
+EVISITOR_TEST_USERNAME=
+EVISITOR_TEST_PASSWORD=
+EVISITOR_TEST_API_KEY=
 
 # Optional: override the Gemini model. Defaults to "gemini-2.5-flash".
 # Note: gemini-2.0-flash is DEPRECATED and shuts down 2026-06-01.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,10 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
-        "eslint": "^10",
+        "eslint": "9.39.5",
         "eslint-config-next": "^16.2.12",
         "tailwindcss": "^4",
+        "tsx": "4.23.12",
         "typescript": "^6",
         "vitest": "^4.1.6"
       }
@@ -851,6 +852,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -894,68 +1337,105 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^10.2.4"
+        "minimatch": "^3.1.5"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -4501,13 +4981,6 @@
         "@types/estree": "*"
       }
     },
-    "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -6100,6 +6573,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -7175,6 +7678,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -7204,30 +7749,34 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
-      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
-        "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^9.1.2",
-        "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
-        "esquery": "^1.7.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -7237,7 +7786,8 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -7245,7 +7795,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -7512,19 +8062,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
-      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@types/esrecurse": "^4.3.1",
-        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -7543,19 +8091,45 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
-      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.16.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^5.0.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -8339,6 +8913,19 @@
       "license": "BSD-2-Clause",
       "peer": true
     },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -8413,7 +9000,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -9849,6 +10435,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",
@@ -12495,6 +13088,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -12868,6 +13474,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "eslint": "^10",
+    "eslint": "9.39.5",
     "eslint-config-next": "^16.2.12",
     "tailwindcss": "^4",
+    "tsx": "4.23.12",
     "typescript": "^6",
     "vitest": "^4.1.6"
   },

--- a/prisma/push-schema.ts
+++ b/prisma/push-schema.ts
@@ -27,6 +27,50 @@ console.log(`Pushing schema to: ${config.label}`);
 const adapter = new PrismaLibSql({ url: config.url, authToken: config.authToken });
 const prisma = new PrismaClient({ adapter });
 
+async function runAdditiveMigration(sql: string): Promise<void> {
+  const addColumn = sql.match(/^ALTER TABLE "([A-Za-z0-9_]+)" ADD COLUMN "([A-Za-z0-9_]+)"/i);
+  if (addColumn) {
+    const [, table, column] = addColumn;
+    const tableRows = await prisma.$queryRawUnsafe<Array<{ name: string }>>(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+      table,
+    );
+    // Fresh databases create some optional tables later in this script. Their
+    // full CREATE TABLE definitions already include the new columns.
+    if (tableRows.length === 0) {
+      console.log(`DEFER: ${table}.${column} (table will be created below)`);
+      return;
+    }
+    const columns = await prisma.$queryRawUnsafe<Array<{ name: string }>>(
+      `PRAGMA table_info("${table}")`,
+    );
+    if (columns.some((entry) => entry.name === column)) {
+      console.log(`SKIP: ${table}.${column} already exists`);
+      return;
+    }
+  }
+
+  const createIndex = sql.match(
+    /^CREATE (?:UNIQUE )?INDEX IF NOT EXISTS "[A-Za-z0-9_]+" ON "([A-Za-z0-9_]+)"/i,
+  );
+  if (createIndex) {
+    const [, table] = createIndex;
+    const tableRows = await prisma.$queryRawUnsafe<Array<{ name: string }>>(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+      table,
+    );
+    if (tableRows.length === 0) {
+      console.log(`DEFER: index for ${table} (table will be created below)`);
+      return;
+    }
+  }
+
+  // CREATE INDEX statements use IF NOT EXISTS. Any remaining error is a real
+  // schema problem and must abort deployment.
+  await prisma.$executeRawUnsafe(sql);
+  console.log("OK:", sql.substring(0, 70) + "...");
+}
+
 const schema = `
 CREATE TABLE IF NOT EXISTS "User" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -148,12 +192,8 @@ CREATE TABLE IF NOT EXISTS "SyncLog" (
     .filter((s) => s.length > 0);
 
   for (const stmt of calendarStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // Migrations: add new columns if missing
@@ -294,20 +334,11 @@ CREATE INDEX IF NOT EXISTS "Feedback_userId_idx" ON "Feedback"("userId");
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
   for (const stmt of feedbackStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
   for (const sql of migrations) {
-    try {
-      await prisma.$executeRawUnsafe(sql);
-      console.log("OK:", sql.substring(0, 70) + "...");
-    } catch {
-      // Column already exists
-    }
+    await runAdditiveMigration(sql);
   }
 
   // Backfill the durable linked-event metadata introduced above. Older rows
@@ -412,12 +443,8 @@ CREATE INDEX IF NOT EXISTS "AuditLog_userId_createdAt_idx" ON "AuditLog"("userId
     .filter((s) => s.length > 0);
 
   for (const stmt of auditStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // CleanerAssignment table — owner ↔ cleaner ↔ property
@@ -442,12 +469,8 @@ CREATE INDEX IF NOT EXISTS "CleanerAssignment_propertyId_idx" ON "CleanerAssignm
     .filter((s) => s.length > 0);
 
   for (const stmt of cleanerStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // RT-25.10 tick 1 — Cleaner profile table (account-level metadata,
@@ -471,12 +494,8 @@ CREATE INDEX IF NOT EXISTS "Cleaner_ownerUserId_idx" ON "Cleaner"("ownerUserId")
     .filter((s) => s.length > 0);
 
   for (const stmt of cleanerProfileStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // RT-25.10 tick 1 — extend CleanerAssignment with cleanerProfileId
@@ -539,38 +558,27 @@ CREATE INDEX IF NOT EXISTS "Cleaner_ownerUserId_idx" ON "Cleaner"("ownerUserId")
     } else {
       // Table already nullable — just make sure the new columns + index exist.
       if (!hasProfileIdCol) {
-        try {
-          await prisma.$executeRawUnsafe(
-            `ALTER TABLE "CleanerAssignment" ADD COLUMN "cleanerProfileId" INTEGER`,
-          );
-          console.log("OK: added cleanerProfileId column");
-        } catch {
-          /* already added */
-        }
+        await prisma.$executeRawUnsafe(
+          `ALTER TABLE "CleanerAssignment" ADD COLUMN "cleanerProfileId" INTEGER`,
+        );
+        console.log("OK: added cleanerProfileId column");
       }
       if (!hasPriorityCol) {
-        try {
-          await prisma.$executeRawUnsafe(
-            `ALTER TABLE "CleanerAssignment" ADD COLUMN "priority" INTEGER NOT NULL DEFAULT 0`,
-          );
-          console.log("OK: added priority column");
-        } catch {
-          /* already added */
-        }
-      }
-      try {
         await prisma.$executeRawUnsafe(
-          `CREATE UNIQUE INDEX IF NOT EXISTS "CleanerAssignment_cleanerProfileId_propertyId_key" ON "CleanerAssignment"("cleanerProfileId", "propertyId")`,
+          `ALTER TABLE "CleanerAssignment" ADD COLUMN "priority" INTEGER NOT NULL DEFAULT 0`,
         );
-        await prisma.$executeRawUnsafe(
-          `CREATE INDEX IF NOT EXISTS "CleanerAssignment_cleanerProfileId_idx" ON "CleanerAssignment"("cleanerProfileId")`,
-        );
-      } catch {
-        /* already exists */
+        console.log("OK: added priority column");
       }
+      await prisma.$executeRawUnsafe(
+        `CREATE UNIQUE INDEX IF NOT EXISTS "CleanerAssignment_cleanerProfileId_propertyId_key" ON "CleanerAssignment"("cleanerProfileId", "propertyId")`,
+      );
+      await prisma.$executeRawUnsafe(
+        `CREATE INDEX IF NOT EXISTS "CleanerAssignment_cleanerProfileId_idx" ON "CleanerAssignment"("cleanerProfileId")`,
+      );
     }
   } catch (err) {
     console.error("CleanerAssignment migration failed:", err);
+    throw err;
   }
 
   // RT-25.10 tick 1 — backfill Cleaner profiles for existing User
@@ -642,6 +650,7 @@ CREATE INDEX IF NOT EXISTS "Cleaner_ownerUserId_idx" ON "Cleaner"("ownerUserId")
     }
   } catch (err) {
     console.error("Cleaner profile backfill failed:", err);
+    throw err;
   }
 
   // PropertyManager table — owner grants management rights to other users
@@ -668,12 +677,8 @@ CREATE INDEX IF NOT EXISTS "PropertyManager_managerId_idx" ON "PropertyManager"(
     .filter((s) => s.length > 0);
 
   for (const stmt of managerStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // PropertyManagerInvite — invite tokens for granting manager access via link
@@ -704,12 +709,8 @@ CREATE INDEX IF NOT EXISTS "PropertyManagerInvite_token_idx" ON "PropertyManager
     .filter((s) => s.length > 0);
 
   for (const stmt of inviteStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // MessageTemplate table — guest pre/post-arrival templates per property
@@ -736,12 +737,8 @@ CREATE INDEX IF NOT EXISTS "MessageTemplate_propertyId_idx" ON "MessageTemplate"
     .filter((s) => s.length > 0);
 
   for (const stmt of messageTemplateStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // CleaningRecord table — track cleaning status per property × date
@@ -770,12 +767,8 @@ CREATE INDEX IF NOT EXISTS "CleaningRecord_propertyId_date_idx" ON "CleaningReco
     .filter((s) => s.length > 0);
 
   for (const stmt of cleaningRecordStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // DateOverride table for manual open/close of calendar dates
@@ -799,12 +792,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "DateOverride_propertyId_date_key" ON "DateOve
     .filter((s) => s.length > 0);
 
   for (const stmt of dateOverrideStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // SiteSetting — global key/value config for admin panel
@@ -825,12 +814,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "SiteSetting_key_key" ON "SiteSetting"("key");
     .filter((s) => s.length > 0);
 
   for (const stmt of siteSettingStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // OnboardingDraft — anonymous /onboard wizard state, claimed at signup
@@ -839,6 +824,7 @@ CREATE TABLE IF NOT EXISTS "OnboardingDraft" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "sessionToken" TEXT NOT NULL,
     "propertyName" TEXT NOT NULL DEFAULT '',
+    "feedSlug" TEXT,
     "links" TEXT NOT NULL DEFAULT '[]',
     "claimedByUserId" INTEGER,
     "claimedAt" DATETIME,
@@ -847,6 +833,7 @@ CREATE TABLE IF NOT EXISTS "OnboardingDraft" (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS "OnboardingDraft_sessionToken_key" ON "OnboardingDraft"("sessionToken");
+CREATE UNIQUE INDEX IF NOT EXISTS "OnboardingDraft_feedSlug_key" ON "OnboardingDraft"("feedSlug");
 `;
 
   const onboardingDraftStatements = onboardingDraftSchema
@@ -855,12 +842,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "OnboardingDraft_sessionToken_key" ON "Onboard
     .filter((s) => s.length > 0);
 
   for (const stmt of onboardingDraftStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // ExtractionLog — one row per /api/extract POST for daily quota counting
@@ -882,12 +865,8 @@ CREATE INDEX IF NOT EXISTS "ExtractionLog_userId_createdAt_idx" ON "ExtractionLo
     .filter((s) => s.length > 0);
 
   for (const stmt of extractionLogStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // BlogPost / BlogTag / BlogComment — RT-20.1 blog data model
@@ -899,10 +878,14 @@ CREATE TABLE IF NOT EXISTS "BlogPost" (
     "title" TEXT NOT NULL,
     "excerpt" TEXT NOT NULL DEFAULT '',
     "body" TEXT NOT NULL DEFAULT '',
+    "tldr" TEXT NOT NULL DEFAULT '',
+    "faqJson" TEXT NOT NULL DEFAULT '[]',
     "status" TEXT NOT NULL DEFAULT 'draft',
     "authorId" INTEGER NOT NULL,
     "tagsJson" TEXT NOT NULL DEFAULT '[]',
     "ogImageUrl" TEXT,
+    "ogImageWidth" INTEGER,
+    "ogImageHeight" INTEGER,
     "translationGroupId" INTEGER,
     "publishedAt" DATETIME,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -948,12 +931,8 @@ CREATE INDEX IF NOT EXISTS "BlogComment_status_createdAt_idx" ON "BlogComment"("
     .filter((s) => s.length > 0);
 
   for (const stmt of blogStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // SeoOverride — RT-18.3 per-page SEO overrides
@@ -980,12 +959,8 @@ CREATE INDEX IF NOT EXISTS "SeoOverride_path_idx" ON "SeoOverride"("path");
     .filter((s) => s.length > 0);
 
   for (const stmt of seoOverrideStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // Seed default SiteSetting keys (idempotent — only inserts if missing)
@@ -1002,16 +977,12 @@ CREATE INDEX IF NOT EXISTS "SeoOverride_path_idx" ON "SeoOverride"("path");
     { key: "seo_default_og_image", value: "" },
   ];
   for (const { key, value } of siteSettingDefaults) {
-    try {
-      await prisma.$executeRawUnsafe(
-        `INSERT INTO "SiteSetting" ("key", "value") VALUES (?, ?) ON CONFLICT("key") DO NOTHING`,
-        key,
-        value,
-      );
-      console.log("OK: seed SiteSetting", key);
-    } catch (err) {
-      console.error("Seed failed for", key, err);
-    }
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO "SiteSetting" ("key", "value") VALUES (?, ?) ON CONFLICT("key") DO NOTHING`,
+      key,
+      value,
+    );
+    console.log("OK: seed SiteSetting", key);
   }
 
   // CalendarPlatform — RT-17.1 platform preset registry
@@ -1042,12 +1013,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "CalendarPlatform_slug_key" ON "CalendarPlatfo
     .filter((s) => s.length > 0);
 
   for (const stmt of platformStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // Seed the 12 baseline platform presets. Direct gets zero buffer
@@ -1077,9 +1044,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "CalendarPlatform_slug_key" ON "CalendarPlatfo
   ];
 
   for (const p of platformPresets) {
-    try {
-      await prisma.$executeRawUnsafe(
-        `INSERT INTO "CalendarPlatform"
+    await prisma.$executeRawUnsafe(
+      `INSERT INTO "CalendarPlatform"
           ("slug", "displayName", "color", "defaultBufferBefore", "defaultBufferAfter",
            "importInstructionsKey", "exportInstructionsKey", "isCustom", "enabled", "sortOrder")
          VALUES (?, ?, ?, ?, ?, ?, ?, 0, 1, ?)
@@ -1092,11 +1058,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS "CalendarPlatform_slug_key" ON "CalendarPlatfo
         `platform.${p.slug}.import`,
         `platform.${p.slug}.export`,
         p.sortOrder,
-      );
-      console.log("OK: seed CalendarPlatform", p.slug);
-    } catch (err) {
-      console.error("Seed failed for CalendarPlatform", p.slug, err);
-    }
+    );
+    console.log("OK: seed CalendarPlatform", p.slug);
   }
 
   // GuestFormTemplate / GuestFormSubmission — RT-25.2 pre-arrival guest forms
@@ -1140,6 +1103,26 @@ CREATE UNIQUE INDEX IF NOT EXISTS "GuestFormSubmission_tokenHash_key" ON "GuestF
 CREATE INDEX IF NOT EXISTS "GuestFormSubmission_reservationId_idx" ON "GuestFormSubmission"("reservationId");
 CREATE INDEX IF NOT EXISTS "GuestFormSubmission_templateId_idx" ON "GuestFormSubmission"("templateId");
 CREATE INDEX IF NOT EXISTS "GuestFormSubmission_status_idx" ON "GuestFormSubmission"("status");
+
+CREATE TABLE IF NOT EXISTS "EVisitorReceipt" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "reservationId" INTEGER NOT NULL,
+    "guestId" TEXT NOT NULL,
+    "eVisitorGuid" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "environment" TEXT NOT NULL DEFAULT 'test',
+    "status" TEXT NOT NULL,
+    "requestHash" TEXT NOT NULL,
+    "attemptedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "readbackConfirmedAt" DATETIME,
+    "attemptCount" INTEGER NOT NULL DEFAULT 1,
+    "failureCode" TEXT,
+    CONSTRAINT "EVisitorReceipt_reservationId_fkey" FOREIGN KEY ("reservationId") REFERENCES "Reservation" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "EVisitorReceipt_reservationId_guestId_action_requestHash_key" ON "EVisitorReceipt"("reservationId", "guestId", "action", "requestHash");
+CREATE INDEX IF NOT EXISTS "EVisitorReceipt_eVisitorGuid_idx" ON "EVisitorReceipt"("eVisitorGuid");
+CREATE INDEX IF NOT EXISTS "EVisitorReceipt_reservationId_guestId_idx" ON "EVisitorReceipt"("reservationId", "guestId");
 `;
 
   const guestFormStatements = guestFormSchema
@@ -1148,12 +1131,8 @@ CREATE INDEX IF NOT EXISTS "GuestFormSubmission_status_idx" ON "GuestFormSubmiss
     .filter((s) => s.length > 0);
 
   for (const stmt of guestFormStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   // EmailCode — short-lived 6-digit codes for email-verified signup and
@@ -1183,12 +1162,8 @@ CREATE INDEX IF NOT EXISTS "EmailCode_email_purpose_idx" ON "EmailCode"("email",
     .filter((s) => s.length > 0);
 
   for (const stmt of emailCodeStatements) {
-    try {
-      await prisma.$executeRawUnsafe(stmt);
-      console.log("OK:", stmt.substring(0, 60) + "...");
-    } catch {
-      // Table/index already exists
-    }
+    await prisma.$executeRawUnsafe(stmt);
+    console.log("OK:", stmt.substring(0, 60) + "...");
   }
 
   console.log(`\nSchema pushed to ${config.label} successfully!`);

--- a/prisma/push-schema.ts
+++ b/prisma/push-schema.ts
@@ -249,6 +249,21 @@ CREATE TABLE IF NOT EXISTS "SyncLog" (
     // chat WhatsApp / Telegram deeplinks on reservations that have no
     // passport guests yet (or only one).
     `ALTER TABLE "Reservation" ADD COLUMN "phone" TEXT`,
+    `ALTER TABLE "Reservation" ADD COLUMN "bookedGuestCount" INTEGER`,
+    // Unified pre-check-in hardening. Raw public tokens and identity payloads
+    // are encrypted with GUEST_DATA_ENCRYPTION_KEY; tokenHash is used for
+    // constant-shape lookups. Existing legacy submissions remain readable and
+    // can be revoked/rotated by the owner without a destructive migration.
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "tokenHash" TEXT`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "tokenCiphertext" TEXT`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "status" TEXT NOT NULL DEFAULT 'NOT_INVITED'`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "expiresAt" DATETIME`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "revokedAt" DATETIME`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "securePayload" TEXT NOT NULL DEFAULT ''`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "ownerApprovedAt" DATETIME`,
+    `ALTER TABLE "GuestFormSubmission" ADD COLUMN "lastChangedAt" DATETIME`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "GuestFormSubmission_tokenHash_key" ON "GuestFormSubmission"("tokenHash")`,
+    `CREATE INDEX IF NOT EXISTS "GuestFormSubmission_status_idx" ON "GuestFormSubmission"("status")`,
   ];
 
   // Feedback table — site-wide visitor feedback queue. New table, so we
@@ -1104,6 +1119,14 @@ CREATE TABLE IF NOT EXISTS "GuestFormSubmission" (
     "reservationId" INTEGER NOT NULL,
     "templateId" INTEGER NOT NULL,
     "shareToken" TEXT NOT NULL,
+    "tokenHash" TEXT,
+    "tokenCiphertext" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'NOT_INVITED',
+    "expiresAt" DATETIME,
+    "revokedAt" DATETIME,
+    "securePayload" TEXT NOT NULL DEFAULT '',
+    "ownerApprovedAt" DATETIME,
+    "lastChangedAt" DATETIME,
     "answers" TEXT NOT NULL DEFAULT '[]',
     "submittedAt" DATETIME,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1113,8 +1136,10 @@ CREATE TABLE IF NOT EXISTS "GuestFormSubmission" (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS "GuestFormSubmission_shareToken_key" ON "GuestFormSubmission"("shareToken");
+CREATE UNIQUE INDEX IF NOT EXISTS "GuestFormSubmission_tokenHash_key" ON "GuestFormSubmission"("tokenHash");
 CREATE INDEX IF NOT EXISTS "GuestFormSubmission_reservationId_idx" ON "GuestFormSubmission"("reservationId");
 CREATE INDEX IF NOT EXISTS "GuestFormSubmission_templateId_idx" ON "GuestFormSubmission"("templateId");
+CREATE INDEX IF NOT EXISTS "GuestFormSubmission_status_idx" ON "GuestFormSubmission"("status");
 `;
 
   const guestFormStatements = guestFormSchema

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,6 +301,9 @@ model Reservation {
   // booking) and use it to deeplink straight into a personal WhatsApp /
   // Telegram chat. Stored in the same loose E.164 shape Guest.phone uses.
   phone           String?
+  // Confirmed party size. iCal imports usually cannot provide it, so legacy
+  // rows may remain null until the owner confirms the booking details.
+  bookedGuestCount Int?
   propertyId      Int
   property        Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
   guests          Guest[]
@@ -547,6 +550,19 @@ model GuestFormSubmission {
   templateId    Int
   template      GuestFormTemplate @relation(fields: [templateId], references: [id], onDelete: Cascade)
   shareToken    String            @unique
+  // New links are looked up by SHA-256 hash. `shareToken` remains for
+  // backwards compatibility with already-issued links; for new rows it holds
+  // only a non-secret legacy marker. The raw token is encrypted so an
+  // authenticated owner can copy the same link again without storing it in
+  // plaintext.
+  tokenHash      String?           @unique
+  tokenCiphertext String?
+  status         String            @default("NOT_INVITED")
+  expiresAt      DateTime?
+  revokedAt      DateTime?
+  securePayload  String            @default("")
+  ownerApprovedAt DateTime?
+  lastChangedAt  DateTime?
   // JSON: ordered list of { fieldId, type, label, value }. Captured at
   // submit time so template edits don't retroactively change history.
   answers       String            @default("[]")
@@ -556,6 +572,7 @@ model GuestFormSubmission {
 
   @@index([reservationId])
   @@index([templateId])
+  @@index([status])
 }
 
 model CalendarPlatform {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -308,6 +308,7 @@ model Reservation {
   property        Property @relation(fields: [propertyId], references: [id], onDelete: Cascade)
   guests          Guest[]
   guestFormSubmissions GuestFormSubmission[]
+  eVisitorReceipts EVisitorReceipt[]
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
@@ -573,6 +574,28 @@ model GuestFormSubmission {
   @@index([reservationId])
   @@index([templateId])
   @@index([status])
+}
+
+model EVisitorReceipt {
+  id                  Int         @id @default(autoincrement())
+  reservationId       Int
+  reservation         Reservation @relation(fields: [reservationId], references: [id], onDelete: Cascade)
+  // Stable server-issued ID stored inside the encrypted pre-check-in payload.
+  // It is intentionally not the browser's clientId and contains no PII.
+  guestId             String
+  eVisitorGuid        String
+  action              String
+  environment         String      @default("test")
+  status              String
+  requestHash         String
+  attemptedAt         DateTime    @default(now())
+  readbackConfirmedAt DateTime?
+  attemptCount        Int         @default(1)
+  failureCode         String?
+
+  @@unique([reservationId, guestId, action, requestHash])
+  @@index([eVisitorGuid])
+  @@index([reservationId, guestId])
 }
 
 model CalendarPlatform {

--- a/src/app/api/extract/route.ts
+++ b/src/app/api/extract/route.ts
@@ -41,6 +41,13 @@ export async function POST(request: NextRequest) {
     }
     userId = session.userId;
 
+    if (process.env.NEXT_PUBLIC_LEGACY_PASSPORT_OCR_ENABLED !== "true") {
+      return NextResponse.json(
+        { error: "Legacy passport OCR is disabled pending a verified retention and deletion lifecycle" },
+        { status: 503 },
+      );
+    }
+
     // Daily per-user quota — count successful + failed attempts in the last 24h
     // and reject before doing any Gemini work if the user is at or above the
     // configured limit. "0" or non-numeric disables the gate.

--- a/src/app/api/g/[token]/draft/route.ts
+++ b/src/app/api/g/[token]/draft/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { checkRateLimit, clientIp } from "@/lib/rate-limit";
+import { findSubmissionByPublicToken, publicSubmissionState, sameOriginRequest } from "@/lib/guest-form-security";
+import { encryptGuestData, hashShareToken } from "@/lib/precheckin-crypto";
+import { sanitizePrecheckinDraft } from "@/lib/precheckin";
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  try {
+    const { token } = await params;
+    if (!token || token.length < 32 || token.length > 180) {
+      return NextResponse.json({ error: "Invalid token" }, { status: 400 });
+    }
+    if (!sameOriginRequest(request)) return NextResponse.json({ error: "Invalid origin" }, { status: 403 });
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (contentLength > 256_000) return NextResponse.json({ error: "Request too large" }, { status: 413 });
+    const limit = checkRateLimit(`guest-draft:${hashShareToken(token)}:${clientIp(request)}`, 60, 15 * 60);
+    if (!limit.ok) {
+      return NextResponse.json(
+        { error: "Too many attempts" },
+        { status: 429, headers: { "Retry-After": String(limit.resetSeconds) } },
+      );
+    }
+    const submission = await findSubmissionByPublicToken(token);
+    if (!submission) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    if (!submission.reservation.property.feedToken) {
+      return NextResponse.json({ error: "Secure calendar-feed setup is incomplete" }, { status: 503 });
+    }
+    const state = publicSubmissionState(submission);
+    if (state !== "active") {
+      return NextResponse.json({ error: "This link is no longer editable." }, { status: 409 });
+    }
+    const body = await request.json().catch(() => null);
+    const draft = sanitizePrecheckinDraft(body?.precheckin);
+    await prisma.guestFormSubmission.update({
+      where: { id: submission.id },
+      data: {
+        securePayload: encryptGuestData(draft),
+        status: "IN_PROGRESS",
+        lastChangedAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    return NextResponse.json({ success: true, status: "IN_PROGRESS" });
+  } catch (err) {
+    console.error("Guest draft save failed:", err instanceof Error ? err.message : "unknown");
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/g/[token]/submit/route.ts
+++ b/src/app/api/g/[token]/submit/route.ts
@@ -4,6 +4,7 @@ import { checkRateLimit, clientIp } from "@/lib/rate-limit";
 import { encryptGuestData, hashShareToken } from "@/lib/precheckin-crypto";
 import { findSubmissionByPublicToken, publicSubmissionState, sameOriginRequest } from "@/lib/guest-form-security";
 import { validatePrecheckinPayload } from "@/lib/precheckin";
+import { randomUUID } from "node:crypto";
 
 // RT-25.2 — public submit endpoint for the pre-arrival guest form.
 // Anyone with the share token can POST once; subsequent POSTs to an
@@ -102,7 +103,15 @@ export async function POST(
     if (!validation.ok || !validation.payload) {
       return NextResponse.json({ error: "Traveler data is incomplete", fields: validation.errors }, { status: 400 });
     }
-    const securePayload = encryptGuestData(validation.payload);
+    const securePayload = encryptGuestData({
+      ...validation.payload,
+      travelers: validation.payload.travelers.map((traveler) => ({
+        ...traveler,
+        // Do not trust the browser's clientId as the durable identity used by
+        // eVisitor receipts and duplicate-send protection.
+        guestId: randomUUID(),
+      })),
+    });
 
     await prisma.guestFormSubmission.update({
       where: { id: submission.id },

--- a/src/app/api/g/[token]/submit/route.ts
+++ b/src/app/api/g/[token]/submit/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
+import { checkRateLimit, clientIp } from "@/lib/rate-limit";
+import { encryptGuestData, hashShareToken } from "@/lib/precheckin-crypto";
+import { findSubmissionByPublicToken, publicSubmissionState, sameOriginRequest } from "@/lib/guest-form-security";
+import { validatePrecheckinPayload } from "@/lib/precheckin";
 
 // RT-25.2 — public submit endpoint for the pre-arrival guest form.
 // Anyone with the share token can POST once; subsequent POSTs to an
@@ -20,16 +24,30 @@ export async function POST(
 ) {
   try {
     const { token } = await params;
-    if (!token || token.length < 16) {
+    if (!token || token.length < 32 || token.length > 180) {
       return NextResponse.json({ error: "Invalid token" }, { status: 400 });
     }
+    if (!sameOriginRequest(request)) return NextResponse.json({ error: "Invalid origin" }, { status: 403 });
+    const contentLength = Number(request.headers.get("content-length") ?? "0");
+    if (contentLength > 256_000) return NextResponse.json({ error: "Request too large" }, { status: 413 });
+    const limit = checkRateLimit(`guest-submit:${hashShareToken(token)}:${clientIp(request)}`, 8, 15 * 60);
+    if (!limit.ok) {
+      return NextResponse.json(
+        { error: "Too many attempts" },
+        { status: 429, headers: { "Retry-After": String(limit.resetSeconds) } },
+      );
+    }
 
-    const submission = await prisma.guestFormSubmission.findUnique({
-      where: { shareToken: token },
-      include: { template: true },
-    });
+    const submission = await findSubmissionByPublicToken(token);
     if (!submission) return NextResponse.json({ error: "Not found" }, { status: 404 });
-    if (submission.submittedAt) {
+    if (!submission.reservation.property.feedToken) {
+      return NextResponse.json({ error: "Secure calendar-feed setup is incomplete" }, { status: 503 });
+    }
+    const state = publicSubmissionState(submission);
+    if (state === "revoked" || state === "expired") {
+      return NextResponse.json({ error: "This link is no longer active." }, { status: 410 });
+    }
+    if (state === "submitted") {
       return NextResponse.json(
         { error: "This form has already been submitted." },
         { status: 409 }
@@ -71,18 +89,39 @@ export async function POST(
       });
     }
 
+    const checkIn = submission.reservation.checkIn.toISOString().slice(0, 10);
+    const checkOut = submission.reservation.checkOut.toISOString().slice(0, 10);
+    const validation = validatePrecheckinPayload(
+      { ...(body?.precheckin ?? {}), customAnswers: answers },
+      {
+        checkIn,
+        checkOut,
+        maxTravelers: submission.reservation.bookedGuestCount ?? undefined,
+      },
+    );
+    if (!validation.ok || !validation.payload) {
+      return NextResponse.json({ error: "Traveler data is incomplete", fields: validation.errors }, { status: 400 });
+    }
+    const securePayload = encryptGuestData(validation.payload);
+
     await prisma.guestFormSubmission.update({
       where: { id: submission.id },
       data: {
-        answers: JSON.stringify(answers),
+        // New structured submissions are encrypted as one canonical payload.
+        // `answers` remains only for reading legacy rows created before this
+        // hardening change.
+        answers: "[]",
+        securePayload,
+        status: "OWNER_REVIEW_REQUIRED",
         submittedAt: new Date(),
+        lastChangedAt: new Date(),
         updatedAt: new Date(),
       },
     });
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, status: "OWNER_REVIEW_REQUIRED" });
   } catch (err) {
-    console.error("Route error:", err);
+    console.error("Guest submit failed:", err instanceof Error ? err.message : "unknown");
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/reservations/[id]/guest-form/share/route.ts
+++ b/src/app/api/reservations/[id]/guest-form/share/route.ts
@@ -1,8 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { randomBytes } from "node:crypto";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "@/lib/auth";
 import { canManageProperty } from "@/lib/ownership";
+import {
+  decryptGuestData,
+  encryptGuestData,
+  guestDataEncryptionReady,
+  hashShareToken,
+  maskDocumentNumber,
+} from "@/lib/precheckin-crypto";
+import {
+  decryptOwnerShareToken,
+  guestFormExpiry,
+  mintGuestFormToken,
+} from "@/lib/guest-form-security";
+import { precheckinWarnings, type PrecheckinPayload } from "@/lib/precheckin";
 
 // RT-25.2 — find-or-create a GuestFormSubmission for this reservation
 // against the property's first GuestFormTemplate. Returns the share
@@ -10,12 +22,6 @@ import { canManageProperty } from "@/lib/ownership";
 // Idempotent: re-POSTing returns the same submission (and same token)
 // rather than creating duplicates, so the UI can call this every time
 // the host clicks "send pre-arrival form".
-
-function mintShareToken(): string {
-  // 24 random bytes → 32-char base64url. Long enough that brute force
-  // is infeasible; short enough to fit in a paste/link without wrap.
-  return randomBytes(24).toString("base64url");
-}
 
 interface AnswerOut {
   fieldId: string;
@@ -34,6 +40,7 @@ export async function GET(
   try {
     const session = await getSession();
     if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (session.impersonatorId) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
     const { id } = await params;
     const numId = parseInt(id);
@@ -62,13 +69,56 @@ export async function GET(
       // malformed JSON — treat as empty
     }
 
+    let securePayload: PrecheckinPayload | null = null;
+    if (submission.securePayload) {
+      try {
+        securePayload = decryptGuestData<PrecheckinPayload>(submission.securePayload);
+      } catch {
+        // Fail closed: a missing/wrong key must never fall back to plaintext.
+      }
+    }
+    const rawToken = decryptOwnerShareToken(submission.tokenCiphertext);
+
     return NextResponse.json({
       submission: {
-        shareToken: submission.shareToken,
-        shareUrl: `/g/${submission.shareToken}`,
+        shareUrl: rawToken
+          ? `/g/${rawToken}`
+          : submission.tokenHash
+            ? null
+            : `/g/${submission.shareToken}`,
         sentAt: submission.createdAt,
         submittedAt: submission.submittedAt,
-        answers: submission.submittedAt ? answers : [],
+        status: submission.status,
+        expiresAt: submission.expiresAt,
+        revokedAt: submission.revokedAt,
+        ownerApprovedAt: submission.ownerApprovedAt,
+        lastChangedAt: submission.lastChangedAt,
+        travelerCount: securePayload?.travelers.length ?? 0,
+        warnings: securePayload ? precheckinWarnings(securePayload) : [],
+        travelers: securePayload?.travelers.map((traveler) => ({
+          clientId: traveler.clientId,
+          isLead: traveler.isLead,
+          firstName: traveler.firstName,
+          lastName: traveler.lastName,
+          dateOfBirth: traveler.dateOfBirth,
+          gender: traveler.gender,
+          citizenshipCountry: traveler.citizenshipCountry,
+          birthCountry: traveler.birthCountry,
+          birthPlace: traveler.birthPlace,
+          residenceCountry: traveler.residenceCountry,
+          residencePlace: traveler.residencePlace,
+          residenceAddress: traveler.residenceAddress,
+          documentType: traveler.documentType,
+          documentNumber: traveler.documentNumber,
+          documentNumberMasked: maskDocumentNumber(traveler.documentNumber),
+          borderEntryDate: traveler.borderEntryDate,
+          borderEntryPlace: traveler.borderEntryPlace,
+          borderEntryPoint: traveler.borderEntryPoint,
+          taxCategorySuggestion: traveler.taxCategorySuggestion,
+        })) ?? [],
+        answers: submission.submittedAt
+          ? securePayload?.customAnswers ?? answers
+          : [],
       },
     });
   } catch (err) {
@@ -84,6 +134,7 @@ export async function POST(
   try {
     const session = await getSession();
     if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (session.impersonatorId) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
     const { id } = await params;
     const numId = parseInt(id);
@@ -91,7 +142,13 @@ export async function POST(
 
     const reservation = await prisma.reservation.findUnique({
       where: { id: numId },
-      select: { id: true, propertyId: true },
+      select: {
+        id: true,
+        propertyId: true,
+        checkOut: true,
+        bookedGuestCount: true,
+        property: { select: { feedToken: true } },
+      },
     });
     if (!reservation) return NextResponse.json({ error: "Not found" }, { status: 404 });
     if (!(await canManageProperty(reservation.propertyId, session.userId, session.role))) {
@@ -109,28 +166,136 @@ export async function POST(
       );
     }
 
+    if (!reservation.property.feedToken) {
+      return NextResponse.json(
+        { error: "Protect the property's public calendar feeds before collecting identity data" },
+        { status: 409 },
+      );
+    }
+
+    if (!reservation.bookedGuestCount) {
+      return NextResponse.json(
+        { error: "Set the confirmed traveler count before generating the guest link" },
+        { status: 409 },
+      );
+    }
+
+    if (!guestDataEncryptionReady()) {
+      return NextResponse.json(
+        { error: "Secure guest-data storage is not configured" },
+        { status: 503 },
+      );
+    }
+
     const existing = await prisma.guestFormSubmission.findFirst({
       where: { reservationId: numId, templateId: template.id },
       orderBy: { createdAt: "asc" },
     });
 
-    const submission =
-      existing ??
-      (await prisma.guestFormSubmission.create({
+    if (existing && !existing.revokedAt && (!existing.expiresAt || existing.expiresAt > new Date())) {
+      const existingToken = decryptOwnerShareToken(existing.tokenCiphertext);
+      if (existingToken) {
+        return NextResponse.json({
+          shareUrl: `/g/${existingToken}`,
+          submittedAt: existing.submittedAt,
+          status: existing.status,
+          expiresAt: existing.expiresAt,
+        });
+      }
+    }
+
+    const rawToken = mintGuestFormToken();
+    const tokenHash = hashShareToken(rawToken);
+    const tokenCiphertext = encryptGuestData({ token: rawToken });
+    const expiresAt = guestFormExpiry(reservation.checkOut);
+    const submission = existing
+      ? await prisma.guestFormSubmission.update({
+          where: { id: existing.id },
+          data: {
+            shareToken: `hashed:${tokenHash}`,
+            tokenHash,
+            tokenCiphertext,
+            status: "INVITED",
+            expiresAt,
+            revokedAt: null,
+            securePayload: "",
+            answers: "[]",
+            submittedAt: null,
+            ownerApprovedAt: null,
+            lastChangedAt: new Date(),
+            updatedAt: new Date(),
+          },
+        })
+      : await prisma.guestFormSubmission.create({
         data: {
           reservationId: numId,
           templateId: template.id,
-          shareToken: mintShareToken(),
+          shareToken: `hashed:${tokenHash}`,
+          tokenHash,
+          tokenCiphertext,
+          status: "INVITED",
+          expiresAt,
+          lastChangedAt: new Date(),
         },
-      }));
+      });
 
     return NextResponse.json({
-      shareToken: submission.shareToken,
-      shareUrl: `/g/${submission.shareToken}`,
+      shareUrl: `/g/${rawToken}`,
       submittedAt: submission.submittedAt,
+      status: submission.status,
+      expiresAt: submission.expiresAt,
     });
   } catch (err) {
     console.error("Route error:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession();
+    if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    if (session.impersonatorId) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const { id } = await params;
+    const reservationId = Number(id);
+    if (!Number.isInteger(reservationId)) return NextResponse.json({ error: "Invalid ID" }, { status: 400 });
+    const reservation = await prisma.reservation.findUnique({
+      where: { id: reservationId },
+      select: { propertyId: true },
+    });
+    if (!reservation || !(await canManageProperty(reservation.propertyId, session.userId, session.role))) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const submission = await prisma.guestFormSubmission.findFirst({
+      where: { reservationId },
+      orderBy: { createdAt: "asc" },
+    });
+    if (!submission) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    const body = await request.json().catch(() => null);
+    const action = body?.action;
+    if (action === "revoke") {
+      await prisma.guestFormSubmission.update({
+        where: { id: submission.id },
+        data: { status: "REVOKED", revokedAt: new Date(), tokenCiphertext: null, lastChangedAt: new Date(), updatedAt: new Date() },
+      });
+      return NextResponse.json({ status: "REVOKED" });
+    }
+    if (action === "approve") {
+      if (submission.status !== "OWNER_REVIEW_REQUIRED" || !submission.securePayload) {
+        return NextResponse.json({ error: "Completed traveler data is required" }, { status: 409 });
+      }
+      await prisma.guestFormSubmission.update({
+        where: { id: submission.id },
+        data: { status: "OWNER_APPROVED", ownerApprovedAt: new Date(), lastChangedAt: new Date(), updatedAt: new Date() },
+      });
+      return NextResponse.json({ status: "OWNER_APPROVED" });
+    }
+    return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+  } catch (err) {
+    console.error("Route error:", err instanceof Error ? err.message : "unknown");
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/api/reservations/[id]/guest-form/share/route.ts
+++ b/src/app/api/reservations/[id]/guest-form/share/route.ts
@@ -109,7 +109,6 @@ export async function GET(
           residencePlace: traveler.residencePlace,
           residenceAddress: traveler.residenceAddress,
           documentType: traveler.documentType,
-          documentNumber: traveler.documentNumber,
           documentNumberMasked: maskDocumentNumber(traveler.documentNumber),
           borderEntryDate: traveler.borderEntryDate,
           borderEntryPlace: traveler.borderEntryPlace,

--- a/src/app/api/reservations/[id]/route.ts
+++ b/src/app/api/reservations/[id]/route.ts
@@ -130,6 +130,23 @@ export async function PATCH(
       }
     }
 
+    if (body.bookedGuestCount !== undefined) {
+      if (body.bookedGuestCount === null || body.bookedGuestCount === "") {
+        data.bookedGuestCount = null;
+      } else if (
+        !Number.isInteger(body.bookedGuestCount) ||
+        body.bookedGuestCount < 1 ||
+        body.bookedGuestCount > 50
+      ) {
+        return NextResponse.json(
+          { error: "bookedGuestCount must be an integer from 1 to 50" },
+          { status: 400 },
+        );
+      } else {
+        data.bookedGuestCount = body.bookedGuestCount;
+      }
+    }
+
     // If the date range is changing, check for overlap with OTHER
     // reservations on the same property. The POST endpoint already
     // does this for new reservations; PATCH was missing the same

--- a/src/app/api/reservations/route.ts
+++ b/src/app/api/reservations/route.ts
@@ -43,6 +43,7 @@ export async function POST(request: NextRequest) {
       linkedEventUid,
       linkedEventPlatform,
       linkedEventRole,
+      bookedGuestCount,
     } = await request.json();
     if (
       typeof name !== "string" ||
@@ -57,7 +58,9 @@ export async function POST(request: NextRequest) {
         typeof linkedEventPlatform !== "string") ||
       (linkedEventRole !== undefined &&
         linkedEventRole !== null &&
-        typeof linkedEventRole !== "string")
+        typeof linkedEventRole !== "string") ||
+      (bookedGuestCount !== undefined &&
+        (!Number.isInteger(bookedGuestCount) || bookedGuestCount < 1 || bookedGuestCount > 50))
     ) {
       return NextResponse.json({ error: "Invalid reservation data" }, { status: 400 });
     }
@@ -262,6 +265,7 @@ export async function POST(request: NextRequest) {
         linkedEventUid: sourceIdentity?.uid || null,
         linkedEventPlatform: sourceIdentity?.platform || null,
         linkedEventRole: sourceRole,
+        ...(bookedGuestCount !== undefined ? { bookedGuestCount } : {}),
         propertyId,
       },
     });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -179,6 +179,7 @@ function AppContent({
       waGroupUrl?: string | null;
       groupName?: string | null;
       phone?: string | null;
+      bookedGuestCount?: number | null;
     }
   ) => {
     const res = await fetch(`/api/reservations/${id}`, {

--- a/src/app/g/[token]/page.tsx
+++ b/src/app/g/[token]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from "next/navigation";
-import { prisma } from "@/lib/prisma";
 import { GuestFormView } from "@/components/guest-form-filler";
 import { sanitizeI18n, type GuestFormI18n } from "@/lib/guest-form-i18n";
+import { findSubmissionByPublicToken, publicSubmissionState } from "@/lib/guest-form-security";
+import { decryptGuestData } from "@/lib/precheckin-crypto";
+import type { PrecheckinDraft } from "@/lib/precheckin";
 
 // RT-25.2 — public pre-arrival guest form. Reachable via the share
 // link the host generated for a specific reservation. Token possession
@@ -22,23 +24,11 @@ export default async function GuestFormPage({
   params: Promise<{ token: string }>;
 }) {
   const { token } = await params;
-  if (!token || token.length < 16) notFound();
+  if (!token || token.length < 32 || token.length > 180) notFound();
 
-  const submission = await prisma.guestFormSubmission.findUnique({
-    where: { shareToken: token },
-    include: {
-      template: true,
-      reservation: {
-        select: {
-          name: true,
-          checkIn: true,
-          checkOut: true,
-          property: { select: { name: true } },
-        },
-      },
-    },
-  });
+  const submission = await findSubmissionByPublicToken(token);
   if (!submission) notFound();
+  const linkState = publicSubmissionState(submission);
 
   const fields: FormField[] = JSON.parse(submission.template.fields);
   let i18n: GuestFormI18n = {};
@@ -46,6 +36,17 @@ export default async function GuestFormPage({
     i18n = sanitizeI18n(JSON.parse(submission.template.i18n || "{}"));
   } catch {
     // Malformed JSON — fall back to English-only.
+  }
+  let initialPrecheckin: PrecheckinDraft | null = null;
+  let storageError = false;
+  if (linkState === "active" && submission.securePayload) {
+    try {
+      initialPrecheckin = decryptGuestData<PrecheckinDraft>(submission.securePayload);
+    } catch {
+      // Never replace an unreadable encrypted draft with an apparently empty
+      // form: that would invite the guest to overwrite recoverable data.
+      storageError = true;
+    }
   }
 
   return (
@@ -58,7 +59,12 @@ export default async function GuestFormPage({
           i18n={i18n}
           propertyName={submission.reservation.property.name}
           guestName={submission.reservation.name}
-          alreadySubmitted={!!submission.submittedAt}
+          checkIn={submission.reservation.checkIn.toISOString().slice(0, 10)}
+          checkOut={submission.reservation.checkOut.toISOString().slice(0, 10)}
+          maxTravelers={submission.reservation.bookedGuestCount ?? null}
+          initialPrecheckin={initialPrecheckin}
+          linkState={!submission.reservation.property.feedToken ? "security-error" : storageError ? "storage-error" : linkState}
+          alreadySubmitted={linkState === "submitted"}
           submittedAt={
             submission.submittedAt
               ? submission.submittedAt.toISOString().slice(0, 10)

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -90,8 +90,8 @@ export default function PrivacyPage() {
             </p>
             <p className="mt-3 font-medium text-[var(--ink)]">(c) Operational data</p>
             <p>
-              Server-side request logs containing path, HTTP status, response time, IP
-              address, and authenticated user ID. Application error reports captured by
+              Server-side request logs containing a redacted path, HTTP status, response time, IP
+              address, and authenticated user ID. Secure guest-form tokens are removed from logged paths. Application error reports captured by
               Sentry (see section 4). Calendar sync logs per property. Audit logs of
               create/update/delete actions on your own resources. Operational data is
               retained for up to 30 days to debug incidents and detect abuse.

--- a/src/components/guest-form-filler.tsx
+++ b/src/components/guest-form-filler.tsx
@@ -441,7 +441,7 @@ function TravelerEditor({
       />
     </label>
   );
-  const nonEu = requiresNonEuBorderFields(text("citizenshipCountry"));
+  const nonEu = requiresNonEuBorderFields(text("residenceCountry"));
   return (
     <fieldset className="rounded-xl border border-[#1e2329] bg-[#11161d] p-4 sm:p-5">
       <legend className="px-1 text-sm font-semibold">Traveler {index + 1}{isLead ? " · lead guest" : ""}</legend>

--- a/src/components/guest-form-filler.tsx
+++ b/src/components/guest-form-filler.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   GUEST_UI_COPY,
   LOCALE_NATIVE_NAME,
@@ -12,6 +12,15 @@ import {
   type GuestPrivacyCopy,
   type GuestUiCopy,
 } from "@/lib/guest-form-i18n";
+import {
+  ARRIVAL_ORGANIZATIONS,
+  COUNTRY_CODES,
+  DOCUMENT_TYPES,
+  GENDERS,
+  SERVICE_TYPES,
+  requiresNonEuBorderFields,
+  type PrecheckinDraft,
+} from "@/lib/precheckin";
 
 interface FormField {
   id: string;
@@ -40,6 +49,11 @@ export function GuestFormView({
   i18n,
   propertyName,
   guestName,
+  checkIn,
+  checkOut,
+  maxTravelers,
+  initialPrecheckin,
+  linkState,
   alreadySubmitted,
   submittedAt,
 }: {
@@ -49,6 +63,11 @@ export function GuestFormView({
   i18n: GuestFormI18n;
   propertyName: string;
   guestName: string;
+  checkIn: string;
+  checkOut: string;
+  maxTravelers: number | null;
+  initialPrecheckin: PrecheckinDraft | null;
+  linkState: "active" | "revoked" | "expired" | "submitted" | "storage-error" | "security-error";
   alreadySubmitted: boolean;
   submittedAt: string | null;
 }) {
@@ -56,12 +75,112 @@ export function GuestFormView({
   const [lang, setLang] = useState<GuestFormLocale>("en");
   const copy = GUEST_UI_COPY[lang];
 
-  const [values, setValues] = useState<Record<string, unknown>>({});
+  const initialAnswers = Object.fromEntries(
+    (initialPrecheckin?.customAnswers ?? []).map((answer) => [answer.fieldId, answer.value]),
+  );
+  const [values, setValues] = useState<Record<string, unknown>>(initialAnswers);
+  const makeTraveler = (isLead: boolean, clientId = "lead-traveler") => ({
+    clientId,
+    isLead,
+    firstName: "",
+    lastName: "",
+    dateOfBirth: "",
+    gender: "",
+    citizenshipCountry: "",
+    birthCountry: "",
+    birthPlace: "",
+    residenceCountry: "",
+    residencePlace: "",
+    residenceAddress: "",
+    documentType: "",
+    documentNumber: "",
+    borderEntryDate: "",
+    borderEntryPlace: "",
+    borderEntryPoint: "",
+  });
+  const [precheckin, setPrecheckin] = useState<PrecheckinDraft>(() => ({
+    expectedArrivalTime: initialPrecheckin?.expectedArrivalTime ?? "",
+    arrivalOrganization: initialPrecheckin?.arrivalOrganization ?? "INDIVIDUAL",
+    serviceType: initialPrecheckin?.serviceType ?? "ACCOMMODATION",
+    travelers: initialPrecheckin?.travelers?.length ? initialPrecheckin.travelers : [makeTraveler(true)],
+    customAnswers: initialPrecheckin?.customAnswers ?? [],
+  }));
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [draftState, setDraftState] = useState<"idle" | "saving" | "saved" | "error">("idle");
 
-  const set = (id: string, v: unknown) => setValues((m) => ({ ...m, [id]: v }));
+  const set = (id: string, v: unknown) => {
+    setValues((m) => ({ ...m, [id]: v }));
+    setDirty(true);
+  };
+
+  const publicDraft = useMemo(() => ({
+    ...precheckin,
+    customAnswers: Object.entries(values).map(([fieldId, value]) => ({ fieldId, value })),
+  }), [precheckin, values]);
+
+  useEffect(() => {
+    if (!dirty || linkState !== "active" || done || alreadySubmitted) return;
+    const timer = window.setTimeout(async () => {
+      setDraftState("saving");
+      try {
+        const response = await fetch(`/api/g/${token}/draft`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ precheckin: publicDraft }),
+        });
+        setDraftState(response.ok ? "saved" : "error");
+      } catch {
+        setDraftState("error");
+      }
+    }, 700);
+    return () => window.clearTimeout(timer);
+  }, [alreadySubmitted, dirty, done, linkState, publicDraft, token]);
+
+  const updateTraveler = (index: number, key: string, value: unknown) => {
+    setPrecheckin((current) => ({
+      ...current,
+      travelers: current.travelers.map((traveler, travelerIndex) =>
+        travelerIndex === index ? { ...traveler, [key]: value } : traveler,
+      ),
+    }));
+    setDirty(true);
+  };
+
+  const addTraveler = () => {
+    if (maxTravelers !== null && precheckin.travelers.length >= maxTravelers) return;
+    setPrecheckin((current) => ({
+      ...current,
+      travelers: [
+        ...current.travelers,
+        makeTraveler(false, typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `traveler-${current.travelers.length + 1}`),
+      ],
+    }));
+    setDirty(true);
+  };
+
+  const removeTraveler = (index: number) => {
+    setPrecheckin((current) => {
+      if (current.travelers.length === 1) return current;
+      const next = current.travelers.filter((_, travelerIndex) => travelerIndex !== index);
+      if (!next.some((traveler) => traveler.isLead)) next[0] = { ...next[0], isLead: true };
+      return { ...current, travelers: next };
+    });
+    setDirty(true);
+  };
+
+  const markLead = (index: number) => {
+    setPrecheckin((current) => ({
+      ...current,
+      travelers: current.travelers.map((traveler, travelerIndex) => ({
+        ...traveler,
+        isLead: travelerIndex === index,
+      })),
+    }));
+    setDirty(true);
+  };
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -71,7 +190,7 @@ export function GuestFormView({
       const res = await fetch(`/api/g/${token}/submit`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ answers: values }),
+        body: JSON.stringify({ answers: values, precheckin: publicDraft }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
@@ -125,7 +244,25 @@ export function GuestFormView({
           settled at that point. */}
       {!alreadySubmitted && <GuestFormPrivacyPanel copy={copy.privacy} />}
 
-      {alreadySubmitted ? (
+      {linkState === "security-error" ? (
+        <div className="rounded-lg border border-rose-500/40 bg-rose-500/5 p-5">
+          <p className="text-sm font-medium text-rose-200">
+            This form is temporarily unavailable while your host completes a security setting. No data was collected.
+          </p>
+        </div>
+      ) : linkState === "storage-error" ? (
+        <div className="rounded-lg border border-rose-500/40 bg-rose-500/5 p-5">
+          <p className="text-sm font-medium text-rose-200">
+            Your saved data cannot be opened securely right now. Nothing was overwritten. Please contact your host.
+          </p>
+        </div>
+      ) : linkState === "revoked" || linkState === "expired" ? (
+        <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-5">
+          <p className="text-sm font-medium text-amber-200">
+            This secure link is no longer active. Please contact your host for a new one.
+          </p>
+        </div>
+      ) : alreadySubmitted ? (
         <div className="rounded-lg border border-emerald-500/40 bg-emerald-500/5 p-5">
           <p className="text-sm font-medium text-emerald-300">{copy.thanks}</p>
           {submittedAt && (
@@ -139,7 +276,81 @@ export function GuestFormView({
           <p className="text-sm font-medium text-emerald-300">{copy.thanks}</p>
         </div>
       ) : (
-        <form onSubmit={submit} className="space-y-4">
+        <form onSubmit={submit} className="space-y-6">
+          <section className="rounded-xl border border-[#1e2329] bg-[#11161d] p-4 sm:p-5">
+            <h2 className="text-lg font-semibold">Stay details</h2>
+            <p className="mt-1 text-xs text-[#a0a0a8]">
+              Reservation: {checkIn} to {checkOut}. These dates come from your reservation and cannot be changed here.
+            </p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className="block">
+                <span className="block text-sm font-medium">Expected arrival time *</span>
+                <input
+                  type="time"
+                  required
+                  value={precheckin.expectedArrivalTime}
+                  onChange={(event) => {
+                    setPrecheckin((current) => ({ ...current, expectedArrivalTime: event.target.value }));
+                    setDirty(true);
+                  }}
+                  className={STRUCTURED_INPUT_CLASS}
+                />
+              </label>
+              <ControlledSelect
+                label="Arrival organization"
+                value={precheckin.arrivalOrganization}
+                options={ARRIVAL_ORGANIZATIONS}
+                onChange={(value) => {
+                  setPrecheckin((current) => ({ ...current, arrivalOrganization: value }));
+                  setDirty(true);
+                }}
+              />
+              <ControlledSelect
+                label="Service type"
+                value={precheckin.serviceType}
+                options={SERVICE_TYPES}
+                onChange={(value) => {
+                  setPrecheckin((current) => ({ ...current, serviceType: value }));
+                  setDirty(true);
+                }}
+              />
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold">Travelers</h2>
+                <p className="text-xs text-[#a0a0a8]">
+                  Enter every person staying, including children.
+                  {maxTravelers !== null ? ` This reservation is for ${maxTravelers}.` : ""}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={addTraveler}
+                disabled={maxTravelers !== null && precheckin.travelers.length >= maxTravelers}
+                className="rounded-md border border-[#2c333d] bg-[#161b22] px-3 py-2 text-xs font-medium"
+              >
+                Add traveler
+              </button>
+            </div>
+            {precheckin.travelers.map((traveler, index) => (
+              <TravelerEditor
+                key={String(traveler.clientId ?? index)}
+                index={index}
+                traveler={traveler}
+                canRemove={precheckin.travelers.length > 1}
+                onChange={(key, value) => updateTraveler(index, key, value)}
+                onRemove={() => removeTraveler(index)}
+                onMarkLead={() => markLead(index)}
+              />
+            ))}
+          </section>
+
+          {fields.length > 0 && (
+            <section className="space-y-4 rounded-xl border border-[#1e2329] bg-[#11161d] p-4 sm:p-5">
+              <h2 className="text-lg font-semibold">Additional questions</h2>
           {fields.map((f) => (
             <FieldInput
               key={f.id}
@@ -150,6 +361,8 @@ export function GuestFormView({
               copy={copy}
             />
           ))}
+            </section>
+          )}
 
           {error && (
             <p className="rounded-md border border-rose-500/40 bg-rose-500/5 px-3 py-2 text-xs text-rose-300">
@@ -164,9 +377,109 @@ export function GuestFormView({
           >
             {busy ? copy.submitting : copy.submit}
           </button>
+          <p aria-live="polite" className="text-center text-[11px] text-[#707782]">
+            {draftState === "saving" ? "Saving encrypted draft…" : draftState === "saved" ? "Encrypted draft saved" : draftState === "error" ? "Draft could not be saved" : ""}
+          </p>
         </form>
       )}
     </div>
+  );
+}
+
+const STRUCTURED_INPUT_CLASS =
+  "mt-1.5 w-full min-w-0 rounded-md border border-[#1e2329] bg-[#161b22] px-3 py-2 text-sm text-[#e8e8ec] focus:border-[#ff385c] focus:outline-none";
+
+function ControlledSelect({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: readonly string[];
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label className="block min-w-0">
+      <span className="block text-sm font-medium">{label} *</span>
+      <select required value={value} onChange={(event) => onChange(event.target.value)} className={STRUCTURED_INPUT_CLASS}>
+        <option value="">Select…</option>
+        {options.map((option) => <option key={option} value={option}>{option.replaceAll("_", " ")}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function TravelerEditor({
+  index,
+  traveler,
+  canRemove,
+  onChange,
+  onRemove,
+  onMarkLead,
+}: {
+  index: number;
+  traveler: Record<string, unknown>;
+  canRemove: boolean;
+  onChange: (key: string, value: unknown) => void;
+  onRemove: () => void;
+  onMarkLead: () => void;
+}) {
+  const text = (key: string) => typeof traveler[key] === "string" ? traveler[key] as string : "";
+  const isLead = traveler.isLead === true;
+  const field = (key: string, label: string, type = "text", autoComplete?: string) => (
+    <label className="block min-w-0">
+      <span className="block text-sm font-medium">{label} *</span>
+      <input
+        type={type}
+        required
+        autoComplete={autoComplete}
+        value={text(key)}
+        onChange={(event) => onChange(key, event.target.value)}
+        className={STRUCTURED_INPUT_CLASS}
+      />
+    </label>
+  );
+  const nonEu = requiresNonEuBorderFields(text("citizenshipCountry"));
+  return (
+    <fieldset className="rounded-xl border border-[#1e2329] bg-[#11161d] p-4 sm:p-5">
+      <legend className="px-1 text-sm font-semibold">Traveler {index + 1}{isLead ? " · lead guest" : ""}</legend>
+      <div className="mb-4 flex flex-wrap gap-2">
+        {!isLead && <button type="button" onClick={onMarkLead} className="rounded-md border border-[#2c333d] px-2.5 py-1.5 text-xs">Make lead guest</button>}
+        {canRemove && <button type="button" onClick={onRemove} className="rounded-md border border-rose-500/30 px-2.5 py-1.5 text-xs text-rose-200">Remove</button>}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {field("firstName", "First name", "text", "given-name")}
+        {field("lastName", "Last name", "text", "family-name")}
+        {field("dateOfBirth", "Date of birth", "date", "bday")}
+        <ControlledSelect label="Gender" value={text("gender")} options={GENDERS} onChange={(value) => onChange("gender", value)} />
+        <ControlledSelect label="Citizenship country" value={text("citizenshipCountry")} options={COUNTRY_CODES} onChange={(value) => onChange("citizenshipCountry", value)} />
+        <ControlledSelect label="Birth country" value={text("birthCountry")} options={COUNTRY_CODES} onChange={(value) => onChange("birthCountry", value)} />
+        {field("birthPlace", "Birth place")}
+        <ControlledSelect label="Residence country" value={text("residenceCountry")} options={COUNTRY_CODES} onChange={(value) => onChange("residenceCountry", value)} />
+        {field("residencePlace", "Residence place")}
+        {field("residenceAddress", "Residence address", "text", "street-address")}
+        <ControlledSelect label="Document type" value={text("documentType")} options={DOCUMENT_TYPES} onChange={(value) => onChange("documentType", value)} />
+        {field("documentNumber", "Document number")}
+        {nonEu && (
+          <>
+            <label className="block min-w-0">
+              <span className="block text-sm font-medium">Border entry date</span>
+              <input type="date" value={text("borderEntryDate")} onChange={(event) => onChange("borderEntryDate", event.target.value)} className={STRUCTURED_INPUT_CLASS} />
+            </label>
+            <label className="block min-w-0">
+              <span className="block text-sm font-medium">Border entry place</span>
+              <input value={text("borderEntryPlace")} onChange={(event) => onChange("borderEntryPlace", event.target.value)} className={STRUCTURED_INPUT_CLASS} />
+            </label>
+            <label className="block min-w-0 sm:col-span-2">
+              <span className="block text-sm font-medium">Border entry point</span>
+              <input value={text("borderEntryPoint")} onChange={(event) => onChange("borderEntryPoint", event.target.value)} className={STRUCTURED_INPUT_CLASS} />
+            </label>
+          </>
+        )}
+      </div>
+    </fieldset>
   );
 }
 

--- a/src/components/guest-form-page.tsx
+++ b/src/components/guest-form-page.tsx
@@ -68,16 +68,8 @@ const WITH_OPTIONS: ReadonlySet<FieldType> = new Set(["select", "multi-select"])
 // The questions hosts ask most often — offered as one-tap presets so a
 // new form can be assembled in seconds with the right field type.
 const SUGGESTED: { label: string; type: FieldType; options?: string[] }[] = [
-  { label: "What time do you expect to arrive?", type: "time" },
-  { label: "Estimated departure time", type: "time" },
-  { label: "How many guests are staying?", type: "number" },
-  { label: "Lead guest full name (as on passport / ID)", type: "short-text" },
-  { label: "Passport / ID number", type: "short-text" },
-  { label: "Nationality", type: "short-text" },
-  { label: "Date of birth", type: "date" },
   { label: "Contact phone number", type: "phone" },
   { label: "Contact email", type: "email" },
-  { label: "How will you travel here?", type: "select", options: ["Car", "Train", "Plane", "Other"] },
   { label: "Do you need a parking space?", type: "yes-no" },
   { label: "Any special requests or questions?", type: "long-text" },
 ];
@@ -434,7 +426,7 @@ export function GuestFormPage({
                         Suggested questions
                       </h3>
                       <p className="mt-0.5 text-xs text-[var(--ink-4)]">
-                        Tap to add a common question — already typed for you.
+                        Traveler identity, document, residence and arrival details are included automatically. Add only optional property questions here.
                       </p>
                       <div className="mt-3 flex flex-wrap gap-1.5">
                         {SUGGESTED.map((s) => {

--- a/src/components/reservation-view.tsx
+++ b/src/components/reservation-view.tsx
@@ -225,6 +225,7 @@ interface ReservationViewProps {
       waGroupUrl?: string | null;
       groupName?: string | null;
       phone?: string | null;
+      bookedGuestCount?: number | null;
     }
   ) => void | Promise<{ ok: true } | { ok: false; error: string }>;
   onUpdateParent: (childId: number, parentId: number | null) => void;
@@ -298,6 +299,10 @@ export function ReservationView({
   const [reservationPhoneDraft, setReservationPhoneDraft] = useState<string>(reservation.phone ?? "");
   const [reservationPhoneSaved, setReservationPhoneSaved] = useState<string>(reservation.phone ?? "");
   const [reservationPhoneState, setReservationPhoneState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [bookedGuestCountDraft, setBookedGuestCountDraft] = useState(
+    reservation.bookedGuestCount ? String(reservation.bookedGuestCount) : "",
+  );
+  const [bookedGuestCountState, setBookedGuestCountState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   useEffect(() => {
     if (reservationPhoneDraft === reservationPhoneSaved) {
       setReservationPhoneDraft(reservation.phone ?? "");
@@ -306,6 +311,11 @@ export function ReservationView({
       setReservationPhoneSaved(reservation.phone ?? "");
     }
   }, [reservation.phone]); // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    setBookedGuestCountDraft(
+      reservation.bookedGuestCount ? String(reservation.bookedGuestCount) : "",
+    );
+  }, [reservation.bookedGuestCount]);
   // RT-25.2 — pre-arrival guest form share link. hasGuestForm gates
   // the "Copy form link" button so it only shows when the property
   // actually has a template configured. The action is link-generation
@@ -318,9 +328,37 @@ export function ReservationView({
   const [guestFormGenerating, setGuestFormGenerating] = useState(false);
   const [guestFormCopyState, setGuestFormCopyState] = useState<"idle" | "copied" | "error">("idle");
   const [guestFormSubmission, setGuestFormSubmission] = useState<{
-    shareUrl: string;
+    shareUrl: string | null;
     sentAt: string;
     submittedAt: string | null;
+    status: "NOT_INVITED" | "INVITED" | "IN_PROGRESS" | "COMPLETE" | "OWNER_REVIEW_REQUIRED" | "OWNER_APPROVED" | "REVOKED";
+    expiresAt: string | null;
+    revokedAt: string | null;
+    ownerApprovedAt: string | null;
+    lastChangedAt: string | null;
+    travelerCount: number;
+    warnings: string[];
+    travelers: Array<{
+      clientId: string;
+      isLead: boolean;
+      firstName: string;
+      lastName: string;
+      dateOfBirth: string;
+      gender: string;
+      citizenshipCountry: string;
+      birthCountry: string;
+      birthPlace: string;
+      residenceCountry: string;
+      residencePlace: string;
+      residenceAddress: string;
+      documentType: string;
+      documentNumber: string;
+      documentNumberMasked: string;
+      borderEntryDate?: string;
+      borderEntryPlace?: string;
+      borderEntryPoint?: string;
+      taxCategorySuggestion?: string;
+    }>;
     answers: { fieldId: string; type: string; label: string; value: unknown }[];
   } | null>(null);
   const logRef = useRef<HTMLDivElement>(null);
@@ -486,6 +524,10 @@ export function ReservationView({
 
   const guestFormStatusLabel = (): string | null => {
     if (!guestFormSubmission) return null;
+    if (guestFormSubmission.status === "REVOKED") return "Link revoked";
+    if (guestFormSubmission.status === "OWNER_APPROVED") return "Guest data checked and approved";
+    if (guestFormSubmission.status === "OWNER_REVIEW_REQUIRED") return "Complete — owner review required";
+    if (guestFormSubmission.status === "IN_PROGRESS") return "Guest started — data incomplete";
     if (guestFormSubmission.submittedAt) {
       const days = Math.max(
         0,
@@ -511,6 +553,21 @@ export function ReservationView({
     return days === 0
       ? "Link generated today, awaiting reply"
       : `Link generated ${days} day${days === 1 ? "" : "s"} ago, awaiting reply`;
+  };
+
+  const updateGuestFormStatus = async (action: "approve" | "revoke") => {
+    setGuestFormCopyState("idle");
+    try {
+      const response = await fetch(`/api/reservations/${reservation.id}/guest-form/share`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      if (!response.ok) throw new Error("status update failed");
+      await refreshGuestFormSubmission();
+    } catch {
+      setGuestFormCopyState("error");
+    }
   };
 
   const renderGuestFormAnswerValue = (a: { type: string; value: unknown }) => {
@@ -604,7 +661,8 @@ export function ReservationView({
 
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
-      addLog(`[${i + 1}/${files.length}] Processing: ${file.name} (${(file.size / 1024).toFixed(1)} KB)`, "processing");
+      const safeFileLabel = `document-${i + 1}`;
+      addLog(`[${i + 1}/${files.length}] Processing secure document (${(file.size / 1024).toFixed(1)} KB)`, "processing");
 
       try {
         const formData = new FormData();
@@ -622,7 +680,7 @@ export function ReservationView({
           const errData = await response.json().catch(() => ({}));
           const reason = errData.error || `HTTP ${response.status}`;
           addLog(`[${i + 1}/${files.length}] Failed: ${reason}`, "error");
-          fileResults.push({ name: file.name, status: "failed", reason });
+          fileResults.push({ name: safeFileLabel, status: "failed", reason });
           continue;
         }
 
@@ -630,20 +688,15 @@ export function ReservationView({
         const count = json.data?.length || 0;
 
         if (count > 0) {
-          for (const person of json.data) {
-            addLog(
-              `[${i + 1}/${files.length}] Extracted: ${person.fullName} | ${person.country} | Passport: ${person.passportNumber}`,
-              "success"
-            );
-          }
-          fileResults.push({ name: file.name, status: "success" });
+          addLog(`[${i + 1}/${files.length}] Extracted ${count} traveler record(s)`, "success");
+          fileResults.push({ name: safeFileLabel, status: "success" });
         } else {
-          addLog(`[${i + 1}/${files.length}] No passport data found in ${file.name}`, "error");
-          fileResults.push({ name: file.name, status: "failed", reason: "No passport data found" });
+          addLog(`[${i + 1}/${files.length}] No passport data found`, "error");
+          fileResults.push({ name: safeFileLabel, status: "failed", reason: "No passport data found" });
         }
       } catch {
-        addLog(`[${i + 1}/${files.length}] Network error processing ${file.name}`, "error");
-        fileResults.push({ name: file.name, status: "failed", reason: "Network error" });
+        addLog(`[${i + 1}/${files.length}] Network error processing secure document`, "error");
+        fileResults.push({ name: safeFileLabel, status: "failed", reason: "Network error" });
       }
     }
 
@@ -720,6 +773,28 @@ export function ReservationView({
     setReservationPhoneState("saved");
     setTimeout(
       () => setReservationPhoneState((s) => (s === "saved" ? "idle" : s)),
+      1600,
+    );
+  };
+
+  const handleBookedGuestCountBlur = async () => {
+    const parsed = Number(bookedGuestCountDraft);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 50) {
+      setBookedGuestCountState("error");
+      return;
+    }
+    if (parsed === reservation.bookedGuestCount) return;
+    setBookedGuestCountState("saving");
+    const result = await Promise.resolve(
+      onUpdateReservation(reservation.id, { bookedGuestCount: parsed }),
+    );
+    if (result && typeof result === "object" && "ok" in result && !result.ok) {
+      setBookedGuestCountState("error");
+      return;
+    }
+    setBookedGuestCountState("saved");
+    setTimeout(
+      () => setBookedGuestCountState((state) => state === "saved" ? "idle" : state),
       1600,
     );
   };
@@ -1169,12 +1244,31 @@ export function ReservationView({
                 "Copy the link, then share it with your guest via WhatsApp, SMS, or email."}
             </p>
           </div>
+          <label className="w-full text-xs text-muted-foreground">
+            Confirmed travelers
+            <input
+              type="number"
+              min={1}
+              max={50}
+              value={bookedGuestCountDraft}
+              onChange={(event) => {
+                setBookedGuestCountDraft(event.target.value);
+                setBookedGuestCountState("idle");
+              }}
+              onBlur={handleBookedGuestCountBlur}
+              className="mt-1 h-9 w-28 rounded-md border border-border/60 bg-background px-2 text-sm text-foreground"
+              aria-label="Confirmed travelers"
+            />
+            <span className="ml-2">
+              {bookedGuestCountState === "saving" ? "Saving…" : bookedGuestCountState === "saved" ? "Saved" : bookedGuestCountState === "error" ? "Enter 1–50" : "Required before link generation"}
+            </span>
+          </label>
           <Button
             type="button"
             size="sm"
             variant="outline"
             onClick={copyGuestFormLink}
-            disabled={guestFormGenerating}
+            disabled={guestFormGenerating || !reservation.bookedGuestCount}
             className="rounded-lg text-xs"
           >
             {guestFormGenerating
@@ -1187,6 +1281,27 @@ export function ReservationView({
                     ? "Copy link again"
                     : "Copy form link"}
           </Button>
+          {guestFormSubmission?.status === "OWNER_REVIEW_REQUIRED" && (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => updateGuestFormStatus("approve")}
+              className="rounded-lg text-xs"
+            >
+              Approve checked data
+            </Button>
+          )}
+          {guestFormSubmission && guestFormSubmission.status !== "REVOKED" && (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => updateGuestFormStatus("revoke")}
+              className="rounded-lg text-xs text-rose-300"
+            >
+              Revoke link
+            </Button>
+          )}
         </div>
       )}
 
@@ -1722,6 +1837,46 @@ export function ReservationView({
               </div>
             ))}
           </dl>
+        </div>
+      )}
+
+      {guestFormSubmission && guestFormSubmission.travelers.length > 0 && (
+        <div className="rounded-xl border border-border/60 bg-card/40 p-4">
+          <h3 className="text-sm font-semibold">Guest registration review</h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {guestFormSubmission.travelerCount} traveler{guestFormSubmission.travelerCount === 1 ? "" : "s"} · {guestFormStatusLabel()}
+          </p>
+          {guestFormSubmission.warnings.length > 0 && (
+            <ul className="mt-3 list-disc space-y-1 pl-5 text-xs text-amber-300">
+              {guestFormSubmission.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+            </ul>
+          )}
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {guestFormSubmission.travelers.map((traveler) => (
+              <details key={traveler.clientId} className="rounded-md border border-border/40 bg-background/40 p-3">
+                <summary className="cursor-pointer list-none">
+                <p className="text-sm font-medium">
+                  {traveler.firstName} {traveler.lastName}{traveler.isLead ? " · lead" : ""}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {traveler.documentType} {traveler.documentNumberMasked} · open to review
+                </p>
+                </summary>
+                <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs">
+                  <dt className="text-muted-foreground">Born</dt><dd>{traveler.dateOfBirth}</dd>
+                  <dt className="text-muted-foreground">Birth place</dt><dd>{traveler.birthPlace}, {traveler.birthCountry}</dd>
+                  <dt className="text-muted-foreground">Citizenship</dt><dd>{traveler.citizenshipCountry}</dd>
+                  <dt className="text-muted-foreground">Residence</dt><dd>{traveler.residenceAddress}, {traveler.residencePlace}, {traveler.residenceCountry}</dd>
+                  <dt className="text-muted-foreground">Document</dt><dd>{traveler.documentType} {traveler.documentNumber}</dd>
+                  <dt className="text-muted-foreground">Tax suggestion</dt><dd>{traveler.taxCategorySuggestion ?? "Review required"}</dd>
+                  {traveler.borderEntryDate && <><dt className="text-muted-foreground">Border entry</dt><dd>{traveler.borderEntryDate} · {traveler.borderEntryPlace} · {traveler.borderEntryPoint}</dd></>}
+                </dl>
+              </details>
+            ))}
+          </div>
+          <p className="mt-3 text-[11px] text-muted-foreground">
+            Document numbers stay masked until a traveler is opened. Approval confirms review only; it does not submit anything to eVisitor.{guestFormSubmission.lastChangedAt ? ` Last changed ${new Date(guestFormSubmission.lastChangedAt).toLocaleString()}.` : ""}
+          </p>
         </div>
       )}
 

--- a/src/components/reservation-view.tsx
+++ b/src/components/reservation-view.tsx
@@ -244,6 +244,10 @@ export function ReservationView({
   onUpdateGuest,
 }: ReservationViewProps) {
   const { locale, t: tr } = useI18n();
+  // The legacy OCR path stores passport fields in the older Guest model and
+  // remains disabled until its retention/deletion lifecycle is proven. The
+  // unified encrypted pre-check-in form does not depend on this feature.
+  const legacyPassportOcrEnabled = process.env.NEXT_PUBLIC_LEGACY_PASSPORT_OCR_ENABLED === "true";
   const hint = HINT_COPY[locale];
   const isDirectExtension = reservation.linkedEventRole === "extension";
   const sourcePlatformLabel = reservation.linkedEventPlatform
@@ -352,7 +356,6 @@ export function ReservationView({
       residencePlace: string;
       residenceAddress: string;
       documentType: string;
-      documentNumber: string;
       documentNumberMasked: string;
       borderEntryDate?: string;
       borderEntryPlace?: string;
@@ -1570,6 +1573,7 @@ export function ReservationView({
         {/* Main column — passport documents + guest list */}
         <div className="min-w-0 space-y-6 lg:flex-1">
 
+      {legacyPassportOcrEnabled && <>
       {/* Drop Zone */}
       <div
         {...getRootProps()}
@@ -1697,6 +1701,7 @@ export function ReservationView({
           )}
         </div>
       )}
+      </>}
 
       {/* Guests action row */}
       {(guests.length > 0 || templates.length > 0) && (
@@ -1859,7 +1864,7 @@ export function ReservationView({
                   {traveler.firstName} {traveler.lastName}{traveler.isLead ? " · lead" : ""}
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  {traveler.documentType} {traveler.documentNumberMasked} · open to review
+                  {traveler.documentType} {traveler.documentNumberMasked}
                 </p>
                 </summary>
                 <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs">
@@ -1867,7 +1872,7 @@ export function ReservationView({
                   <dt className="text-muted-foreground">Birth place</dt><dd>{traveler.birthPlace}, {traveler.birthCountry}</dd>
                   <dt className="text-muted-foreground">Citizenship</dt><dd>{traveler.citizenshipCountry}</dd>
                   <dt className="text-muted-foreground">Residence</dt><dd>{traveler.residenceAddress}, {traveler.residencePlace}, {traveler.residenceCountry}</dd>
-                  <dt className="text-muted-foreground">Document</dt><dd>{traveler.documentType} {traveler.documentNumber}</dd>
+                  <dt className="text-muted-foreground">Document</dt><dd>{traveler.documentType} {traveler.documentNumberMasked}</dd>
                   <dt className="text-muted-foreground">Tax suggestion</dt><dd>{traveler.taxCategorySuggestion ?? "Review required"}</dd>
                   {traveler.borderEntryDate && <><dt className="text-muted-foreground">Border entry</dt><dd>{traveler.borderEntryDate} · {traveler.borderEntryPlace} · {traveler.borderEntryPoint}</dd></>}
                 </dl>
@@ -1875,7 +1880,7 @@ export function ReservationView({
             ))}
           </div>
           <p className="mt-3 text-[11px] text-muted-foreground">
-            Document numbers stay masked until a traveler is opened. Approval confirms review only; it does not submit anything to eVisitor.{guestFormSubmission.lastChangedAt ? ` Last changed ${new Date(guestFormSubmission.lastChangedAt).toLocaleString()}.` : ""}
+            Document numbers remain masked in the browser. Approval confirms review only; it does not submit anything to eVisitor.{guestFormSubmission.lastChangedAt ? ` Last changed ${new Date(guestFormSubmission.lastChangedAt).toLocaleString()}.` : ""}
           </p>
         </div>
       )}

--- a/src/lib/evisitor-receipt.test.ts
+++ b/src/lib/evisitor-receipt.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  findUnique: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {
+    eVisitorReceipt: {
+      findUnique: mocks.findUnique,
+      create: mocks.create,
+      update: mocks.update,
+    },
+  },
+}));
+
+import {
+  claimEVisitorReceipt,
+  confirmEVisitorReceipt,
+  failEVisitorReceipt,
+} from "@/lib/evisitor-receipt";
+
+const identity = {
+  reservationId: 77,
+  guestId: "guest-internal-id",
+  eVisitorGuid: "93517b97-c033-4436-a126-b1bd0ecf9b7a",
+  action: "CHECK_IN" as const,
+  requestHash: "a".repeat(64),
+  environment: "test" as const,
+};
+
+beforeEach(() => vi.resetAllMocks());
+
+describe("eVisitor receipts", () => {
+  it("creates a PENDING idempotency receipt without PII", async () => {
+    mocks.findUnique.mockResolvedValue(null);
+    mocks.create.mockResolvedValue({ id: 1 });
+    await claimEVisitorReceipt(identity);
+
+    expect(mocks.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        reservationId: 77,
+        guestId: "guest-internal-id",
+        action: "CHECK_IN",
+        requestHash: "a".repeat(64),
+        status: "PENDING",
+      }),
+    });
+    expect(JSON.stringify(mocks.create.mock.calls)).not.toContain("DocumentNumber");
+  });
+
+  it("blocks a second send after readback confirmation", async () => {
+    mocks.findUnique.mockResolvedValue({ id: 1, status: "READBACK_CONFIRMED" });
+    await expect(claimEVisitorReceipt(identity)).rejects.toThrow("already confirmed");
+    expect(mocks.create).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a technical retry only after a failed attempt", async () => {
+    mocks.findUnique.mockResolvedValue({ id: 1, status: "FAILED" });
+    mocks.update.mockResolvedValue({ id: 1, status: "PENDING" });
+    await claimEVisitorReceipt(identity);
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: expect.objectContaining({ status: "PENDING", attemptCount: { increment: 1 } }),
+    });
+  });
+
+  it("marks success only as readback-confirmed and bounds failure codes", async () => {
+    mocks.update.mockResolvedValue({ id: 1 });
+    await confirmEVisitorReceipt(1);
+    await failEVisitorReceipt(1, "ACTION_HTTP_FAILED");
+
+    expect(mocks.update).toHaveBeenNthCalledWith(1, {
+      where: { id: 1 },
+      data: expect.objectContaining({ status: "READBACK_CONFIRMED" }),
+    });
+    expect(mocks.update).toHaveBeenNthCalledWith(2, {
+      where: { id: 1 },
+      data: { status: "FAILED", failureCode: "ACTION_HTTP_FAILED" },
+    });
+  });
+});

--- a/src/lib/evisitor-receipt.ts
+++ b/src/lib/evisitor-receipt.ts
@@ -1,0 +1,82 @@
+import { prisma } from "@/lib/prisma";
+
+export type EVisitorReceiptAction = "CHECK_IN" | "UPDATE" | "CHECK_OUT" | "CANCEL_CHECK_IN";
+export type EVisitorFailureCode =
+  | "AUTH_FAILED"
+  | "ACTION_HTTP_FAILED"
+  | "READBACK_HTTP_FAILED"
+  | "READBACK_MISMATCH"
+  | "UNKNOWN";
+
+export interface EVisitorReceiptIdentity {
+  reservationId: number;
+  guestId: string;
+  eVisitorGuid: string;
+  action: EVisitorReceiptAction;
+  requestHash: string;
+  environment?: "test" | "production";
+}
+
+/**
+ * Claim one exact eVisitor action. A confirmed or currently pending identical
+ * request is blocked; a failed request can be retried against the same receipt.
+ * The unique DB key closes the concurrent double-click race.
+ */
+export async function claimEVisitorReceipt(identity: EVisitorReceiptIdentity) {
+  const key = {
+    reservationId: identity.reservationId,
+    guestId: identity.guestId,
+    action: identity.action,
+    requestHash: identity.requestHash,
+  };
+  const existing = await prisma.eVisitorReceipt.findUnique({
+    where: { reservationId_guestId_action_requestHash: key },
+  });
+  if (existing?.status === "READBACK_CONFIRMED") {
+    throw new Error("Identical eVisitor action already confirmed");
+  }
+  if (existing?.status === "PENDING") {
+    throw new Error("Identical eVisitor action already in progress");
+  }
+  if (existing) {
+    return prisma.eVisitorReceipt.update({
+      where: { id: existing.id },
+      data: {
+        status: "PENDING",
+        attemptedAt: new Date(),
+        attemptCount: { increment: 1 },
+        failureCode: null,
+      },
+    });
+  }
+  return prisma.eVisitorReceipt.create({
+    data: {
+      ...key,
+      eVisitorGuid: identity.eVisitorGuid,
+      environment: identity.environment ?? "test",
+      status: "PENDING",
+    },
+  });
+}
+
+export async function confirmEVisitorReceipt(id: number): Promise<void> {
+  await prisma.eVisitorReceipt.update({
+    where: { id },
+    data: {
+      status: "READBACK_CONFIRMED",
+      readbackConfirmedAt: new Date(),
+      failureCode: null,
+    },
+  });
+}
+
+export async function failEVisitorReceipt(id: number, failureCode: EVisitorFailureCode): Promise<void> {
+  await prisma.eVisitorReceipt.update({
+    where: { id },
+    data: {
+      status: "FAILED",
+      // This union is deliberately closed: never persist an API body or PII.
+      failureCode,
+    },
+  });
+}

--- a/src/lib/evisitor.test.ts
+++ b/src/lib/evisitor.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrecheckinPayload, PrecheckinTraveler } from "@/lib/precheckin";
+import {
+  buildEVisitorCancel,
+  buildEVisitorCheckIn,
+  buildEVisitorCheckOut,
+  EVISITOR_OWNER_APPROVAL,
+  EVisitorTestClient,
+  hashEVisitorRequest,
+} from "@/lib/evisitor";
+
+const guestId = "6b73dcae-f752-4d8e-9088-acde87fbda58";
+const registrationId = "93517b97-c033-4436-a126-b1bd0ecf9b7a";
+
+const traveler: PrecheckinTraveler = {
+  guestId,
+  clientId: "browser-row-1",
+  isLead: true,
+  firstName: "Synthetic",
+  lastName: "Traveler",
+  dateOfBirth: "1990-04-20",
+  gender: "M",
+  citizenshipCountry: "US",
+  birthCountry: "US",
+  birthPlace: "Testville",
+  residenceCountry: "US",
+  residencePlace: "Example City",
+  residenceAddress: "1 Test Street",
+  documentType: "PASSPORT",
+  documentNumber: "SYNTHETIC-001",
+  borderEntryDate: "2027-05-15",
+  borderEntryPlace: "Synthetic crossing",
+  borderEntryPoint: "Synthetic crossing",
+  taxCategorySuggestion: "STANDARD_ADULT",
+};
+
+const precheckin: PrecheckinPayload = {
+  version: 1,
+  expectedArrivalDate: "2027-05-16",
+  expectedDepartureDate: "2027-05-28",
+  expectedArrivalTime: "14:00",
+  arrivalOrganization: "INDIVIDUAL",
+  serviceType: "ACCOMMODATION",
+  travelers: [traveler],
+  customAnswers: [],
+};
+
+function context() {
+  return {
+    registrationId,
+    facilityCode: "SYNTHETIC-FACILITY",
+    arrivalOrganisationCode: "VERIFIED-ARRIVAL-CODE",
+    offeredServiceType: "VERIFIED-SERVICE",
+    expectedDepartureTime: "10:00",
+    codes: {
+      guestId,
+      citizenshipAlpha3: "USA",
+      countryOfBirthAlpha3: "USA",
+      countryOfResidenceAlpha3: "USA",
+      documentTypeCode: "VERIFIED-DOC-CODE",
+      genderValue: "VERIFIED-GENDER",
+      taxPaymentCategoryCode: "VERIFIED-TAX-CODE",
+      cityOfBirth: "Testville",
+      cityOfResidence: "Example City",
+      borderCrossingCode: "VERIFIED-BORDER-CODE",
+    },
+  };
+}
+
+describe("eVisitor mapping", () => {
+  it("maps every required pre-check-in field without inventing lookup values", () => {
+    const result = buildEVisitorCheckIn(precheckin, traveler, context());
+
+    expect(result).toEqual({
+      ID: registrationId,
+      Facility: "SYNTHETIC-FACILITY",
+      ArrivalOrganisation: "VERIFIED-ARRIVAL-CODE",
+      Citizenship: "USA",
+      CityOfBirth: "Testville",
+      CityOfResidence: "Example City",
+      CountryOfBirth: "USA",
+      CountryOfResidence: "USA",
+      DateOfBirth: "19900420",
+      DocumentNumber: "SYNTHETIC-001",
+      DocumentType: "VERIFIED-DOC-CODE",
+      ForeseenStayUntil: "20270528",
+      Gender: "VERIFIED-GENDER",
+      OfferedServiceType: "VERIFIED-SERVICE",
+      ResidenceAddress: "1 Test Street",
+      StayFrom: "20270516",
+      TimeEstimatedStayUntil: "10:00",
+      TimeStayFrom: "14:00",
+      TouristName: "Synthetic",
+      TouristSurname: "Traveler",
+      TTPaymentCategory: "VERIFIED-TAX-CODE",
+      BorderCrossing: "VERIFIED-BORDER-CODE",
+      PassageDate: "20270515",
+    });
+  });
+
+  it("fails closed when an official lookup value is missing", () => {
+    const unsafe = context();
+    unsafe.codes.taxPaymentCategoryCode = "";
+    expect(() => buildEVisitorCheckIn(precheckin, traveler, unsafe))
+      .toThrow("Missing verified eVisitor value: tax payment category code");
+  });
+
+  it("requires an official border-crossing code for non-EU residents", () => {
+    const unsafe = context();
+    unsafe.codes.borderCrossingCode = undefined as unknown as string;
+    expect(() => buildEVisitorCheckIn(precheckin, traveler, unsafe))
+      .toThrow("Missing verified eVisitor value: border crossing code");
+  });
+
+  it("requires a separate owner-verified agency value", () => {
+    const agencyPayload = { ...precheckin, arrivalOrganization: "TRAVEL_AGENCY" as const };
+    expect(() => buildEVisitorCheckIn(agencyPayload, traveler, context()))
+      .toThrow("Missing verified eVisitor value: tourist agency VAT");
+  });
+
+  it("builds checkout/cancel payloads and hashes without retaining plaintext elsewhere", () => {
+    const checkout = buildEVisitorCheckOut(registrationId, "2027-05-28", "10:00");
+    const cancel = buildEVisitorCancel(registrationId, "Synthetic test cleanup");
+    expect(checkout).toEqual({ ID: registrationId, CheckOutDate: "20270528", CheckOutTime: "10:00" });
+    expect(cancel).toEqual({ ID: registrationId, Reason: "Synthetic test cleanup" });
+    expect(hashEVisitorRequest(checkout)).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashEVisitorRequest(checkout)).not.toContain(registrationId);
+  });
+});
+
+describe("EVisitorTestClient", () => {
+  it("uses only the official test host, enforces Owner approval, and verifies readback", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const request = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      calls.push({ url, init });
+      if (url.endsWith("/Authentication/Login")) {
+        const headers = new Headers();
+        headers.append("set-cookie", "auth=test-only; Path=/; HttpOnly");
+        return new Response("true", { status: 200, headers });
+      }
+      if (url.includes("/ListOfTouristsExtended/")) {
+        return Response.json({ Records: [{ ID: registrationId, CheckedOutTourist: false }] });
+      }
+      if (url.endsWith("/CheckInTourist/")) return new Response("", { status: 200 });
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const client = new EVisitorTestClient(
+      { username: "test-user", password: "test-password", apiKey: "test-key" },
+      request,
+    );
+    await client.login();
+    const payload = buildEVisitorCheckIn(precheckin, traveler, context());
+
+    await expect(client.checkIn(payload, "WRONG" as never)).rejects.toThrow("OWNER_APPROVED_SUBMIT required");
+    const readback = await client.checkIn(payload, EVISITOR_OWNER_APPROVAL);
+
+    expect(readback.ID).toBe(registrationId);
+    expect(calls.every((call) => call.url.startsWith("https://www.evisitor.hr/testApi/"))).toBe(true);
+    expect(calls.some((call) => call.url.includes("eVisitorRhetos_API"))).toBe(false);
+  });
+
+  it("does not report checkout success until readback says checked out", async () => {
+    const request = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/Authentication/Login")) {
+        const headers = new Headers();
+        headers.append("set-cookie", "auth=test-only; Path=/; HttpOnly");
+        return new Response("true", { status: 200, headers });
+      }
+      if (url.includes("/ListOfTouristsExtended/")) {
+        return Response.json({ Records: [{ ID: registrationId, CheckedOutTourist: false }] });
+      }
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const client = new EVisitorTestClient(
+      { username: "test-user", password: "test-password", apiKey: "test-key" },
+      request,
+    );
+    await client.login();
+
+    await expect(client.checkOut(
+      buildEVisitorCheckOut(registrationId, "2027-05-28", "10:00"),
+      EVISITOR_OWNER_APPROVAL,
+    )).rejects.toThrow("eVisitor checkout readback mismatch");
+  });
+});

--- a/src/lib/evisitor.ts
+++ b/src/lib/evisitor.ts
@@ -1,0 +1,321 @@
+import { createHash } from "node:crypto";
+import type { PrecheckinPayload, PrecheckinTraveler } from "@/lib/precheckin";
+
+export const EVISITOR_OWNER_APPROVAL = "OWNER_APPROVED_SUBMIT" as const;
+export type EVisitorOwnerApproval = typeof EVISITOR_OWNER_APPROVAL;
+
+const TEST_API_ROOT = "https://www.evisitor.hr/testApi";
+
+export interface EVisitorResolvedTravelerCodes {
+  guestId: string;
+  citizenshipAlpha3: string;
+  countryOfBirthAlpha3: string;
+  countryOfResidenceAlpha3: string;
+  documentTypeCode: string;
+  genderValue: string;
+  taxPaymentCategoryCode: string;
+  /** Official eVisitor settlement label for Croatian places, or the verified
+   * free-text foreign city accepted by eVisitor. */
+  cityOfBirth: string;
+  cityOfResidence: string;
+  /** Official border-crossing code. Required for non-EU residents. */
+  borderCrossingCode?: string;
+}
+
+export interface EVisitorCheckInContext {
+  registrationId: string;
+  facilityCode: string;
+  accommodationUnitType?: string;
+  arrivalOrganisationCode: string;
+  touristAgencyVat?: string;
+  offeredServiceType: string;
+  expectedDepartureTime: string;
+  codes: EVisitorResolvedTravelerCodes;
+}
+
+export interface EVisitorCheckInPayload {
+  ID: string;
+  Facility: string;
+  AccommodationUnitType?: string;
+  ArrivalOrganisation: string;
+  TouristAgency?: string;
+  Citizenship: string;
+  CityOfBirth: string;
+  CityOfResidence: string;
+  CountryOfBirth: string;
+  CountryOfResidence: string;
+  DateOfBirth: string;
+  DocumentNumber: string;
+  DocumentType: string;
+  ForeseenStayUntil: string;
+  Gender: string;
+  OfferedServiceType: string;
+  ResidenceAddress?: string;
+  StayFrom: string;
+  TimeEstimatedStayUntil: string;
+  TimeStayFrom: string;
+  TouristName: string;
+  TouristSurname: string;
+  TTPaymentCategory: string;
+  BorderCrossing?: string;
+  PassageDate?: string;
+}
+
+export interface EVisitorCheckOutPayload {
+  ID: string;
+  CheckOutDate: string;
+  CheckOutTime: string;
+}
+
+export interface EVisitorCancelPayload {
+  ID: string;
+  Reason: string;
+}
+
+export interface EVisitorTouristReadback {
+  ID: string;
+  FacilityID?: string;
+  CheckedOutTourist?: boolean;
+  StayFrom?: string;
+  ForeseenStayUntil?: string;
+  DateTimeOfArrival?: string;
+  DateTimeOfDeparture?: string;
+  [key: string]: unknown;
+}
+
+function required(value: string | undefined, label: string): string {
+  const normalized = value?.trim();
+  if (!normalized) throw new Error(`Missing verified eVisitor value: ${label}`);
+  return normalized;
+}
+
+function compactDate(value: string, label: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) throw new Error(`Invalid ${label}`);
+  return value.replaceAll("-", "");
+}
+
+function assertTime(value: string, label: string): string {
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) throw new Error(`Invalid ${label}`);
+  return value;
+}
+
+function assertGuid(value: string, label: string): string {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)) {
+    throw new Error(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function isNonEuResident(country: string): boolean {
+  const eu = new Set(
+    "AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE".split(" "),
+  );
+  return !eu.has(country);
+}
+
+/**
+ * Map one owner-reviewed traveler to the exact CheckInTourist action shape.
+ * No lookup value is guessed: every official code/value comes from the
+ * owner-reviewed context populated from eVisitor lookups.
+ */
+export function buildEVisitorCheckIn(
+  precheckin: PrecheckinPayload,
+  traveler: PrecheckinTraveler,
+  context: EVisitorCheckInContext,
+): EVisitorCheckInPayload {
+  const guestId = required(traveler.guestId, "internal guest ID");
+  if (guestId !== context.codes.guestId) throw new Error("Traveler/code mapping mismatch");
+  if (precheckin.arrivalOrganization === "TRAVEL_AGENCY" && !context.touristAgencyVat?.trim()) {
+    throw new Error("Missing verified eVisitor value: tourist agency VAT");
+  }
+
+  const result: EVisitorCheckInPayload = {
+    ID: assertGuid(context.registrationId, "eVisitor registration GUID"),
+    Facility: required(context.facilityCode, "facility code"),
+    ArrivalOrganisation: required(context.arrivalOrganisationCode, "arrival organisation code"),
+    Citizenship: required(context.codes.citizenshipAlpha3, "citizenship ISO alpha-3").toUpperCase(),
+    CityOfBirth: required(context.codes.cityOfBirth, "city of birth"),
+    CityOfResidence: required(context.codes.cityOfResidence, "city of residence"),
+    CountryOfBirth: required(context.codes.countryOfBirthAlpha3, "birth country ISO alpha-3").toUpperCase(),
+    CountryOfResidence: required(context.codes.countryOfResidenceAlpha3, "residence country ISO alpha-3").toUpperCase(),
+    DateOfBirth: compactDate(traveler.dateOfBirth, "date of birth"),
+    DocumentNumber: required(traveler.documentNumber, "document number"),
+    DocumentType: required(context.codes.documentTypeCode, "document type code"),
+    ForeseenStayUntil: compactDate(precheckin.expectedDepartureDate, "expected departure date"),
+    Gender: required(context.codes.genderValue, "gender value"),
+    OfferedServiceType: required(context.offeredServiceType, "offered service type"),
+    ResidenceAddress: traveler.residenceAddress || undefined,
+    StayFrom: compactDate(precheckin.expectedArrivalDate, "arrival date"),
+    TimeEstimatedStayUntil: assertTime(context.expectedDepartureTime, "expected departure time"),
+    TimeStayFrom: assertTime(precheckin.expectedArrivalTime, "arrival time"),
+    TouristName: required(traveler.firstName, "first name"),
+    TouristSurname: required(traveler.lastName, "last name"),
+    TTPaymentCategory: required(context.codes.taxPaymentCategoryCode, "tax payment category code"),
+  };
+
+  if (context.accommodationUnitType?.trim()) result.AccommodationUnitType = context.accommodationUnitType.trim();
+  if (context.touristAgencyVat?.trim()) result.TouristAgency = context.touristAgencyVat.trim();
+
+  if (isNonEuResident(traveler.residenceCountry)) {
+    result.BorderCrossing = required(context.codes.borderCrossingCode, "border crossing code");
+    result.PassageDate = compactDate(required(traveler.borderEntryDate, "border entry date"), "border entry date");
+  }
+  return result;
+}
+
+export function buildEVisitorCheckOut(
+  registrationId: string,
+  checkOutDate: string,
+  checkOutTime: string,
+): EVisitorCheckOutPayload {
+  return {
+    ID: assertGuid(registrationId, "eVisitor registration GUID"),
+    CheckOutDate: compactDate(checkOutDate, "checkout date"),
+    CheckOutTime: assertTime(checkOutTime, "checkout time"),
+  };
+}
+
+export function buildEVisitorCancel(registrationId: string, reason: string): EVisitorCancelPayload {
+  return {
+    ID: assertGuid(registrationId, "eVisitor registration GUID"),
+    Reason: required(reason, "cancellation reason"),
+  };
+}
+
+export function hashEVisitorRequest(payload: object): string {
+  return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
+export interface EVisitorTestCredentials {
+  username: string;
+  password: string;
+  apiKey: string;
+}
+
+type FetchLike = typeof fetch;
+
+/**
+ * Official eVisitor transport restricted to the isolated test environment.
+ * Production is intentionally unsupported until the synthetic E2E and Owner
+ * gates have passed. Credentials are injected by the caller from a secret
+ * manager and are never logged or retained here.
+ */
+export class EVisitorTestClient {
+  private cookieHeader = "";
+
+  constructor(
+    private readonly credentials: EVisitorTestCredentials,
+    private readonly request: FetchLike = fetch,
+  ) {}
+
+  async login(): Promise<void> {
+    const response = await this.request(
+      `${TEST_API_ROOT}/Resources/AspNetFormsAuth/Authentication/Login`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          UserName: required(this.credentials.username, "test username"),
+          Password: required(this.credentials.password, "test password"),
+          apikey: required(this.credentials.apiKey, "test API key"),
+          PersistCookie: false,
+        }),
+        cache: "no-store",
+      },
+    );
+    const body = await response.text();
+    if (!response.ok || body.trim() !== "true") throw new Error("eVisitor test login failed");
+    const headers = response.headers as Headers & { getSetCookie?: () => string[] };
+    const setCookies = headers.getSetCookie?.() ?? [];
+    if (setCookies.length === 0) throw new Error("eVisitor test login returned no cookies");
+    this.cookieHeader = setCookies.map((cookie) => cookie.split(";", 1)[0]).join("; ");
+  }
+
+  async logout(): Promise<void> {
+    if (!this.cookieHeader) return;
+    await this.request(`${TEST_API_ROOT}/Resources/AspNetFormsAuth/Authentication/Logout`, {
+      method: "POST",
+      headers: { cookie: this.cookieHeader },
+      cache: "no-store",
+    });
+    this.cookieHeader = "";
+  }
+
+  async checkIn(
+    payload: EVisitorCheckInPayload,
+    approval: EVisitorOwnerApproval,
+  ): Promise<EVisitorTouristReadback> {
+    this.assertOwnerApproval(approval);
+    await this.action("CheckInTourist", payload);
+    return this.requireReadback(payload.ID);
+  }
+
+  async updateActiveCheckIn(
+    payload: EVisitorCheckInPayload,
+    approval: EVisitorOwnerApproval,
+  ): Promise<EVisitorTouristReadback> {
+    this.assertOwnerApproval(approval);
+    await this.action("CheckInTourist", payload);
+    return this.requireReadback(payload.ID);
+  }
+
+  async checkOut(
+    payload: EVisitorCheckOutPayload,
+    approval: EVisitorOwnerApproval,
+  ): Promise<EVisitorTouristReadback> {
+    this.assertOwnerApproval(approval);
+    await this.action("CheckOutTourist", payload);
+    const readback = await this.requireReadback(payload.ID);
+    if (readback.CheckedOutTourist !== true) throw new Error("eVisitor checkout readback mismatch");
+    return readback;
+  }
+
+  async cancelCheckIn(payload: EVisitorCancelPayload, approval: EVisitorOwnerApproval): Promise<void> {
+    this.assertOwnerApproval(approval);
+    await this.action("CancelTouristCheckIn", payload);
+    const readback = await this.listTouristsExtended(payload.ID);
+    if (readback.length !== 0) throw new Error("eVisitor cancellation readback mismatch");
+  }
+
+  async listTouristsExtended(id: string): Promise<EVisitorTouristReadback[]> {
+    this.assertAuthenticated();
+    const filters = encodeURIComponent(JSON.stringify([
+      { Property: "ID", Operation: "equal", Value: assertGuid(id, "eVisitor registration GUID") },
+    ]));
+    const response = await this.request(
+      `${TEST_API_ROOT}/Rest/Htz/ListOfTouristsExtended/?psize=5&page=1&filters=${filters}`,
+      { method: "GET", headers: { cookie: this.cookieHeader }, cache: "no-store" },
+    );
+    if (!response.ok) throw new Error(`eVisitor test readback failed (${response.status})`);
+    const parsed = await response.json() as { Records?: EVisitorTouristReadback[] };
+    return Array.isArray(parsed.Records) ? parsed.Records : [];
+  }
+
+  private async requireReadback(id: string): Promise<EVisitorTouristReadback> {
+    const records = await this.listTouristsExtended(id);
+    const exact = records.filter((record) => record.ID.toLowerCase() === id.toLowerCase());
+    if (exact.length !== 1) throw new Error("eVisitor readback did not confirm exactly one tourist");
+    return exact[0];
+  }
+
+  private async action(name: string, payload: object): Promise<void> {
+    this.assertAuthenticated();
+    const response = await this.request(`${TEST_API_ROOT}/Rest/Htz/${name}/`, {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie: this.cookieHeader },
+      body: JSON.stringify(payload),
+      cache: "no-store",
+    });
+    if (!response.ok) throw new Error(`eVisitor test action failed (${response.status})`);
+    const body = await response.text();
+    if (body.trim()) throw new Error("eVisitor test action returned an unexpected response");
+  }
+
+  private assertAuthenticated(): void {
+    if (!this.cookieHeader) throw new Error("eVisitor test client is not authenticated");
+  }
+
+  private assertOwnerApproval(approval: EVisitorOwnerApproval): void {
+    if (approval !== EVISITOR_OWNER_APPROVAL) throw new Error("OWNER_APPROVED_SUBMIT required");
+  }
+}

--- a/src/lib/feed-utils.test.ts
+++ b/src/lib/feed-utils.test.ts
@@ -27,6 +27,11 @@ describe("parseFeedFilename", () => {
     expect(parseFeedFilename("for-platform99.ics")).toBe("platform99");
   });
 
+  it("accepts multi-word channel slugs containing hyphens", () => {
+    expect(parseFeedFilename("for-ubytovani-v-chorvatsku.ics"))
+      .toBe("ubytovani-v-chorvatsku");
+  });
+
   it("matches case-insensitively", () => {
     expect(parseFeedFilename("FOR-Vrbo.ICS")).toBe("Vrbo");
   });

--- a/src/lib/feed-utils.ts
+++ b/src/lib/feed-utils.ts
@@ -11,6 +11,11 @@
  * requests rather than 400'ing.
  */
 export function parseFeedFilename(filename: string): string {
-  const match = filename.match(/^for-(\w+)\.ics$/i);
+  // Channel labels created from human-readable names commonly contain
+  // hyphens (for example `ubytovani-v-chorvatsku`). Treat the complete slug
+  // as the target channel; otherwise the legacy fallback to `airbnb` makes
+  // genuine Airbnb stays look like same-channel events and silently omits
+  // them from that destination's feed.
+  const match = filename.match(/^for-([a-z0-9_-]+)\.ics$/i);
   return match?.[1] || "airbnb";
 }

--- a/src/lib/feed.test.ts
+++ b/src/lib/feed.test.ts
@@ -92,6 +92,20 @@ describe("generateFeed — Direct linked extensions", () => {
     ]);
   });
 
+  it("never exposes imported or manual guest names in outgoing iCal", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, summary: "PRIVATE GUEST NAME" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([
+      { ...extension, name: "ANOTHER PRIVATE NAME" },
+    ]);
+    const result = await generateFeed(12, "booking");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.ical).not.toContain("PRIVATE GUEST NAME");
+    expect(result.ical).not.toContain("ANOTHER PRIVATE NAME");
+    expect(result.ical).toContain("Blocked");
+  });
+
   it("routes an explicitly marked extension as Direct during migration", async () => {
     mocks.reservationFindMany.mockResolvedValue([
       { ...extension, platform: "airbnb" },

--- a/src/lib/feed.test.ts
+++ b/src/lib/feed.test.ts
@@ -92,6 +92,64 @@ describe("generateFeed — Direct linked extensions", () => {
     ]);
   });
 
+  it("never exposes imported or manual guest names in outgoing iCal", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, summary: "PRIVATE GUEST NAME" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([
+      { ...extension, name: "ANOTHER PRIVATE NAME" },
+    ]);
+    const result = await generateFeed(12, "booking");
+    if ("error" in result) throw new Error(result.error);
+    expect(result.ical).not.toContain("PRIVATE GUEST NAME");
+    expect(result.ical).not.toContain("ANOTHER PRIVATE NAME");
+    expect(result.ical).toContain("Blocked");
+  });
+
+  it("never exposes source UIDs, internal reservation IDs, or source names", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([
+      {
+        ...source,
+        uid: "airbnb-secret-source-uid",
+        summary: "PRIVATE NAME",
+        email: "private@example.test",
+        phone: "+385000000000",
+        notes: "PRIVATE INTERNAL NOTE",
+      },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([
+      {
+        ...extension,
+        id: 987654321,
+        linkedEventUid: null,
+        email: "reservation@example.test",
+        phone: "+4310000000",
+        notes: "PRIVATE RESERVATION NOTE",
+      },
+    ]);
+
+    const result = await generateFeed(12, "booking");
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.ical).not.toContain("airbnb-secret-source-uid");
+    expect(result.ical).not.toContain("987654321");
+    expect(result.ical).not.toContain("airbnb");
+    expect(result.ical).not.toContain("direct");
+    expect(result.ical).not.toContain("PRIVATE NAME");
+    expect(result.ical).not.toContain("private@example.test");
+    expect(result.ical).not.toContain("reservation@example.test");
+    expect(result.ical).not.toContain("+385000000000");
+    expect(result.ical).not.toContain("+4310000000");
+    expect(result.ical).not.toContain("PRIVATE INTERNAL NOTE");
+    expect(result.ical).not.toContain("PRIVATE RESERVATION NOTE");
+    expect(result.ical).toMatch(/UID:rt-[0-9a-f]{32}/);
+
+    const repeated = await generateFeed(12, "booking");
+    if ("error" in repeated) throw new Error(repeated.error);
+    expect(parseICal(repeated.ical).map((event) => event.uid))
+      .toEqual(parseICal(result.ical).map((event) => event.uid));
+  });
+
   it("routes an explicitly marked extension as Direct during migration", async () => {
     mocks.reservationFindMany.mockResolvedValue([
       { ...extension, platform: "airbnb" },
@@ -107,6 +165,119 @@ describe("generateFeed — Direct linked extensions", () => {
         startDate: "2099-08-23",
         endDate: "2099-08-25",
       }),
+    ]);
+  });
+
+  it("exports confirmed stays from mixed sources to a hyphenated destination", async () => {
+    mocks.calendarLinkFindMany.mockResolvedValue([
+      { platform: "ubytovani-v-chorvatsku", bufferBefore: 0, bufferAfter: 0 },
+    ]);
+    mocks.calendarEventFindMany.mockResolvedValue([
+      {
+        ...source,
+        uid: "airbnb-2026-regression",
+        summary: "PRIVATE IMPORTED NAME",
+        startDate: "2026-08-23",
+        endDate: "2026-09-11",
+        platform: "airbnb",
+      },
+      {
+        ...source,
+        uid: "booking-2027-regression",
+        summary: "ANOTHER PRIVATE NAME",
+        startDate: "2027-06-30",
+        endDate: "2027-07-04",
+        platform: "booking",
+      },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([
+      {
+        ...extension,
+        id: 301,
+        name: "PRIVATE DIRECT NAME 1",
+        checkIn: new Date("2027-05-16T00:00:00.000Z"),
+        checkOut: new Date("2027-05-28T00:00:00.000Z"),
+        platform: "direct",
+        linkedEventUid: null,
+        linkedEventPlatform: null,
+        linkedEventRole: null,
+      },
+      {
+        ...extension,
+        id: 302,
+        name: "PRIVATE DIRECT NAME 2",
+        checkIn: new Date("2027-08-07T00:00:00.000Z"),
+        checkOut: new Date("2027-08-17T00:00:00.000Z"),
+        platform: "direct",
+        linkedEventUid: null,
+        linkedEventPlatform: null,
+        linkedEventRole: null,
+      },
+    ]);
+
+    const result = await generateFeed(12, "ubytovani-v-chorvatsku");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter(
+      (event) => event.uid !== "renttools-placeholder",
+    );
+
+    expect(events.map(({ startDate, endDate }) => ({ startDate, endDate })))
+      .toEqual([
+        { startDate: "2026-08-23", endDate: "2026-09-11" },
+        { startDate: "2027-05-16", endDate: "2027-05-28" },
+        { startDate: "2027-06-30", endDate: "2027-07-04" },
+        { startDate: "2027-08-07", endDate: "2027-08-17" },
+      ]);
+    expect(result.ical).not.toContain("PRIVATE IMPORTED NAME");
+    expect(result.ical).not.toContain("ANOTHER PRIVATE NAME");
+    expect(result.ical).not.toContain("PRIVATE DIRECT NAME 1");
+    expect(result.ical).not.toContain("PRIVATE DIRECT NAME 2");
+  });
+
+  it("deduplicates identical occupancy ranges from multiple sources", async () => {
+    mocks.calendarLinkFindMany.mockResolvedValue([
+      { platform: "ubytovani-v-chorvatsku", bufferBefore: 0, bufferAfter: 0 },
+    ]);
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, uid: "airbnb-copy", startDate: "2027-08-07", endDate: "2027-08-17", platform: "airbnb" },
+      { ...source, uid: "booking-copy", startDate: "2027-08-07", endDate: "2027-08-17", platform: "booking" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([]);
+
+    const result = await generateFeed(12, "ubytovani-v-chorvatsku");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter((event) => event.uid !== "renttools-placeholder");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(expect.objectContaining({
+      startDate: "2027-08-07",
+      endDate: "2027-08-17",
+    }));
+  });
+
+  it("drops a cancelled imported stay once sync removes it from the active event set", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([]);
+    mocks.reservationFindMany.mockResolvedValue([]);
+
+    const result = await generateFeed(12, "booking");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter((event) => event.uid !== "renttools-placeholder");
+
+    expect(events).toEqual([]);
+  });
+
+  it("exports a Booking stay with checkout kept exclusive", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, uid: "booking-only", startDate: "2027-06-30", endDate: "2027-07-04", platform: "booking" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([]);
+
+    const result = await generateFeed(12, "airbnb");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter((event) => event.uid !== "renttools-placeholder");
+
+    expect(events).toEqual([
+      expect.objectContaining({ startDate: "2027-06-30", endDate: "2027-07-04" }),
     ]);
   });
 });

--- a/src/lib/feed.test.ts
+++ b/src/lib/feed.test.ts
@@ -106,6 +106,24 @@ describe("generateFeed — Direct linked extensions", () => {
     expect(result.ical).toContain("Blocked");
   });
 
+  it("never exposes source UIDs, internal reservation IDs, or source names", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, uid: "airbnb-secret-source-uid", summary: "PRIVATE NAME" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([
+      { ...extension, id: 987654321, linkedEventUid: null },
+    ]);
+
+    const result = await generateFeed(12, "booking");
+    if ("error" in result) throw new Error(result.error);
+
+    expect(result.ical).not.toContain("airbnb-secret-source-uid");
+    expect(result.ical).not.toContain("987654321");
+    expect(result.ical).not.toContain("airbnb");
+    expect(result.ical).not.toContain("direct");
+    expect(result.ical).not.toContain("PRIVATE NAME");
+  });
+
   it("routes an explicitly marked extension as Direct during migration", async () => {
     mocks.reservationFindMany.mockResolvedValue([
       { ...extension, platform: "airbnb" },
@@ -121,6 +139,119 @@ describe("generateFeed — Direct linked extensions", () => {
         startDate: "2099-08-23",
         endDate: "2099-08-25",
       }),
+    ]);
+  });
+
+  it("exports confirmed stays from mixed sources to a hyphenated destination", async () => {
+    mocks.calendarLinkFindMany.mockResolvedValue([
+      { platform: "ubytovani-v-chorvatsku", bufferBefore: 0, bufferAfter: 0 },
+    ]);
+    mocks.calendarEventFindMany.mockResolvedValue([
+      {
+        ...source,
+        uid: "airbnb-2026-regression",
+        summary: "PRIVATE IMPORTED NAME",
+        startDate: "2026-08-23",
+        endDate: "2026-09-11",
+        platform: "airbnb",
+      },
+      {
+        ...source,
+        uid: "booking-2027-regression",
+        summary: "ANOTHER PRIVATE NAME",
+        startDate: "2027-06-30",
+        endDate: "2027-07-04",
+        platform: "booking",
+      },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([
+      {
+        ...extension,
+        id: 301,
+        name: "PRIVATE DIRECT NAME 1",
+        checkIn: new Date("2027-05-16T00:00:00.000Z"),
+        checkOut: new Date("2027-05-28T00:00:00.000Z"),
+        platform: "direct",
+        linkedEventUid: null,
+        linkedEventPlatform: null,
+        linkedEventRole: null,
+      },
+      {
+        ...extension,
+        id: 302,
+        name: "PRIVATE DIRECT NAME 2",
+        checkIn: new Date("2027-08-07T00:00:00.000Z"),
+        checkOut: new Date("2027-08-17T00:00:00.000Z"),
+        platform: "direct",
+        linkedEventUid: null,
+        linkedEventPlatform: null,
+        linkedEventRole: null,
+      },
+    ]);
+
+    const result = await generateFeed(12, "ubytovani-v-chorvatsku");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter(
+      (event) => event.uid !== "renttools-placeholder",
+    );
+
+    expect(events.map(({ startDate, endDate }) => ({ startDate, endDate })))
+      .toEqual([
+        { startDate: "2026-08-23", endDate: "2026-09-11" },
+        { startDate: "2027-05-16", endDate: "2027-05-28" },
+        { startDate: "2027-06-30", endDate: "2027-07-04" },
+        { startDate: "2027-08-07", endDate: "2027-08-17" },
+      ]);
+    expect(result.ical).not.toContain("PRIVATE IMPORTED NAME");
+    expect(result.ical).not.toContain("ANOTHER PRIVATE NAME");
+    expect(result.ical).not.toContain("PRIVATE DIRECT NAME 1");
+    expect(result.ical).not.toContain("PRIVATE DIRECT NAME 2");
+  });
+
+  it("deduplicates identical occupancy ranges from multiple sources", async () => {
+    mocks.calendarLinkFindMany.mockResolvedValue([
+      { platform: "ubytovani-v-chorvatsku", bufferBefore: 0, bufferAfter: 0 },
+    ]);
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, uid: "airbnb-copy", startDate: "2027-08-07", endDate: "2027-08-17", platform: "airbnb" },
+      { ...source, uid: "booking-copy", startDate: "2027-08-07", endDate: "2027-08-17", platform: "booking" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([]);
+
+    const result = await generateFeed(12, "ubytovani-v-chorvatsku");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter((event) => event.uid !== "renttools-placeholder");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual(expect.objectContaining({
+      startDate: "2027-08-07",
+      endDate: "2027-08-17",
+    }));
+  });
+
+  it("drops a cancelled imported stay once sync removes it from the active event set", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([]);
+    mocks.reservationFindMany.mockResolvedValue([]);
+
+    const result = await generateFeed(12, "booking");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter((event) => event.uid !== "renttools-placeholder");
+
+    expect(events).toEqual([]);
+  });
+
+  it("exports a Booking stay with checkout kept exclusive", async () => {
+    mocks.calendarEventFindMany.mockResolvedValue([
+      { ...source, uid: "booking-only", startDate: "2027-06-30", endDate: "2027-07-04", platform: "booking" },
+    ]);
+    mocks.reservationFindMany.mockResolvedValue([]);
+
+    const result = await generateFeed(12, "airbnb");
+    if ("error" in result) throw new Error(result.error);
+    const events = parseICal(result.ical).filter((event) => event.uid !== "renttools-placeholder");
+
+    expect(events).toEqual([
+      expect.objectContaining({ startDate: "2027-06-30", endDate: "2027-07-04" }),
     ]);
   });
 });

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { generateICal, generateBufferedEvents, generateBufferOnlyEvents, addDays, type ICalEvent } from "@/lib/ical";
+import { createHash } from "node:crypto";
 
 export { parseFeedFilename } from "@/lib/feed-utils";
 
@@ -12,6 +13,18 @@ function reservationChannel(reservation: {
 }): string {
   if (reservation.linkedEventRole === "extension") return "direct";
   return reservation.platform || "airbnb";
+}
+
+/**
+ * Public iCal feeds are bearer-readable. Keep their VEVENT identifiers stable
+ * without exposing an imported platform UID or an internal database ID.
+ */
+function opaqueEventUid(...parts: Array<string | number | null | undefined>): string {
+  const digest = createHash("sha256")
+    .update(parts.map((part) => String(part ?? "")).join("\u001f"))
+    .digest("hex")
+    .slice(0, 32);
+  return `rt-${digest}`;
 }
 
 /**
@@ -116,12 +129,17 @@ export async function generateFeed(propertyId: number, forPlatform: string): Pro
   // Other-platform events (block dates + buffer)
   const otherEvents: ICalEvent[] = allEvents
     .filter(e => e.platform !== forPlatform)
-    .map(e => ({ uid: e.uid, summary: e.summary || "Blocked", startDate: e.startDate, endDate: e.endDate }));
+    .map(e => ({
+      uid: opaqueEventUid("calendar-event", propertyId, e.platform, e.uid),
+      summary: "Blocked",
+      startDate: e.startDate,
+      endDate: e.endDate,
+    }));
 
   for (const res of allReservations.filter(r => reservationChannel(r) !== forPlatform)) {
     otherEvents.push({
-      uid: `renttool-reservation-${res.id}`,
-      summary: `${res.name} (${reservationChannel(res)})`,
+      uid: opaqueEventUid("reservation", propertyId, res.id),
+      summary: "Blocked",
       startDate: new Date(res.checkIn).toISOString().substring(0, 10),
       endDate: new Date(res.checkOut).toISOString().substring(0, 10),
     });
@@ -130,11 +148,16 @@ export async function generateFeed(propertyId: number, forPlatform: string): Pro
   // Same-platform events (buffer-only)
   const sameEvents: ICalEvent[] = allEvents
     .filter(e => e.platform === forPlatform)
-    .map(e => ({ uid: `own-${e.uid}`, summary: "Buffer", startDate: e.startDate, endDate: e.endDate }));
+    .map(e => ({
+      uid: opaqueEventUid("same-platform-event", propertyId, e.platform, e.uid),
+      summary: "Buffer",
+      startDate: e.startDate,
+      endDate: e.endDate,
+    }));
 
   for (const res of allReservations.filter(r => reservationChannel(r) === forPlatform)) {
     sameEvents.push({
-      uid: `own-res-${res.id}`,
+      uid: opaqueEventUid("same-platform-reservation", propertyId, res.id),
       summary: "Buffer",
       startDate: new Date(res.checkIn).toISOString().substring(0, 10),
       endDate: new Date(res.checkOut).toISOString().substring(0, 10),
@@ -210,6 +233,16 @@ export async function generateFeed(propertyId: number, forPlatform: string): Pro
     });
   }
 
-  const ical = generateICal(finalEvents, `RentTool - Blocked for ${forPlatform}`);
+  // The buffer/merge helpers intentionally rebuild UIDs from their inputs.
+  // Re-key the final public events once more so neither dates, source UIDs nor
+  // internal IDs leak through the bearer-readable feed. The date range is part
+  // of the hash input, keeping the opaque identifier stable across refreshes.
+  const publicEvents = finalEvents.map((event) => ({
+    ...event,
+    uid: opaqueEventUid("feed-event", propertyId, forPlatform, event.startDate, event.endDate),
+    summary: "Blocked",
+  }));
+
+  const ical = generateICal(publicEvents, `RentTool - Blocked for ${forPlatform}`);
   return { ical };
 }

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { generateICal, generateBufferedEvents, generateBufferOnlyEvents, addDays, type ICalEvent } from "@/lib/ical";
+import { createHash } from "node:crypto";
 
 export { parseFeedFilename } from "@/lib/feed-utils";
 
@@ -12,6 +13,18 @@ function reservationChannel(reservation: {
 }): string {
   if (reservation.linkedEventRole === "extension") return "direct";
   return reservation.platform || "airbnb";
+}
+
+/**
+ * Public iCal feeds are bearer-readable. Keep their VEVENT identifiers stable
+ * without exposing an imported platform UID or an internal database ID.
+ */
+function opaqueEventUid(...parts: Array<string | number | null | undefined>): string {
+  const digest = createHash("sha256")
+    .update(parts.map((part) => String(part ?? "")).join("\u001f"))
+    .digest("hex")
+    .slice(0, 32);
+  return `rt-${digest}`;
 }
 
 /**
@@ -118,12 +131,17 @@ export async function generateFeed(propertyId: number, forPlatform: string): Pro
     .filter(e => e.platform !== forPlatform)
     // Imported summaries commonly contain guest names. Public iCal URLs are
     // bearer links, so outgoing feeds must expose inventory only, never PII.
-    .map(e => ({ uid: e.uid, summary: `Blocked (${e.platform})`, startDate: e.startDate, endDate: e.endDate }));
+    .map(e => ({
+      uid: opaqueEventUid("calendar-event", propertyId, e.platform, e.uid),
+      summary: "Blocked",
+      startDate: e.startDate,
+      endDate: e.endDate,
+    }));
 
   for (const res of allReservations.filter(r => reservationChannel(r) !== forPlatform)) {
     otherEvents.push({
-      uid: `renttool-reservation-${res.id}`,
-      summary: `Blocked (${reservationChannel(res)})`,
+      uid: opaqueEventUid("reservation", propertyId, res.id),
+      summary: "Blocked",
       startDate: new Date(res.checkIn).toISOString().substring(0, 10),
       endDate: new Date(res.checkOut).toISOString().substring(0, 10),
     });
@@ -132,11 +150,16 @@ export async function generateFeed(propertyId: number, forPlatform: string): Pro
   // Same-platform events (buffer-only)
   const sameEvents: ICalEvent[] = allEvents
     .filter(e => e.platform === forPlatform)
-    .map(e => ({ uid: `own-${e.uid}`, summary: "Buffer", startDate: e.startDate, endDate: e.endDate }));
+    .map(e => ({
+      uid: opaqueEventUid("same-platform-event", propertyId, e.platform, e.uid),
+      summary: "Buffer",
+      startDate: e.startDate,
+      endDate: e.endDate,
+    }));
 
   for (const res of allReservations.filter(r => reservationChannel(r) === forPlatform)) {
     sameEvents.push({
-      uid: `own-res-${res.id}`,
+      uid: opaqueEventUid("same-platform-reservation", propertyId, res.id),
       summary: "Buffer",
       startDate: new Date(res.checkIn).toISOString().substring(0, 10),
       endDate: new Date(res.checkOut).toISOString().substring(0, 10),

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -116,12 +116,14 @@ export async function generateFeed(propertyId: number, forPlatform: string): Pro
   // Other-platform events (block dates + buffer)
   const otherEvents: ICalEvent[] = allEvents
     .filter(e => e.platform !== forPlatform)
-    .map(e => ({ uid: e.uid, summary: e.summary || "Blocked", startDate: e.startDate, endDate: e.endDate }));
+    // Imported summaries commonly contain guest names. Public iCal URLs are
+    // bearer links, so outgoing feeds must expose inventory only, never PII.
+    .map(e => ({ uid: e.uid, summary: `Blocked (${e.platform})`, startDate: e.startDate, endDate: e.endDate }));
 
   for (const res of allReservations.filter(r => reservationChannel(r) !== forPlatform)) {
     otherEvents.push({
       uid: `renttool-reservation-${res.id}`,
-      summary: `${res.name} (${reservationChannel(res)})`,
+      summary: `Blocked (${reservationChannel(res)})`,
       startDate: new Date(res.checkIn).toISOString().substring(0, 10),
       endDate: new Date(res.checkOut).toISOString().substring(0, 10),
     });

--- a/src/lib/guest-form-i18n.ts
+++ b/src/lib/guest-form-i18n.ts
@@ -167,21 +167,21 @@ export const GUEST_UI_COPY: Record<GuestFormLocale, GuestUiCopy> = {
     privacy: {
       title: "Privacy & data handling",
       summary:
-        "Only your host sees your answers. Stored on RentTools.io — open-source software, HTTPS only, no tracking.",
+        "Used for legally required guest registration and stay management — not marketing. Identity data is encrypted at rest and in transit.",
       showDetails: "Details",
       hideDetails: "Hide",
       bullets: [
         {
           title: "Who sees this",
-          body: "Only the host of the property you booked. Answers go straight to their RentTools account. Nothing is shared, sold, or used for advertising.",
+          body: "The host and an explicitly authorised property manager. Cleaners and RentTools support impersonation cannot access the identity payload. Nothing is sold or used for advertising.",
         },
         {
           title: "Where it's stored",
-          body: "RentTools.io is an open-source tool — the source code is public so anyone can verify what happens to your data. The connection to this form is HTTPS-encrypted.",
+          body: "The identity payload is application-encrypted before database storage. The connection to this form is HTTPS-encrypted. Uploaded ID images are not part of this form.",
         },
         {
           title: "No tracking",
-          body: "No analytics, no advertising cookies, no third-party scripts are loaded on this page. Only the cookie required to keep your submission attached to your booking.",
+          body: "No analytics or advertising cookies are loaded on this page. If you choose a language or theme, RentTools may store only that technical preference; the secure URL token attaches the form to the reservation.",
         },
         {
           title: "Your rights (GDPR / UK GDPR)",
@@ -209,21 +209,21 @@ export const GUEST_UI_COPY: Record<GuestFormLocale, GuestUiCopy> = {
     privacy: {
       title: "Конфиденциальность и обработка данных",
       summary:
-        "Ваши ответы видит только хозяин объекта. Данные хранятся на RentTools.io — открытое ПО, только HTTPS, без отслеживания.",
+        "Данные используются для обязательной регистрации гостей и управления проживанием, а не для маркетинга. Идентификационные данные шифруются при хранении и передаче.",
       showDetails: "Подробнее",
       hideDetails: "Свернуть",
       bullets: [
         {
           title: "Кто видит эти данные",
-          body: "Только хозяин выбранного вами объекта. Ответы попадают сразу в его аккаунт RentTools. Мы не передаём, не продаём и не используем их в рекламных целях.",
+          body: "Хозяин и явно уполномоченный управляющий объектом. Уборщики и служба поддержки RentTools в режиме имитации не имеют доступа к идентификационным данным. Данные не продаются и не используются для рекламы.",
         },
         {
           title: "Где хранятся данные",
-          body: "RentTools.io — это открытое программное обеспечение, исходный код общедоступен, поэтому любой может проверить, что происходит с вашими данными. Соединение с этой формой защищено HTTPS-шифрованием.",
+          body: "Идентификационные данные шифруются приложением до сохранения в базе. Соединение с формой защищено HTTPS. Загрузка фотографий документов в этом формуляре отключена.",
         },
         {
           title: "Никакого отслеживания",
-          body: "На этой странице нет аналитики, рекламных cookies или сторонних скриптов. Используется только cookie, необходимый, чтобы связать ваш ответ с конкретной бронью.",
+          body: "На этой странице нет аналитики и рекламных cookies. Может сохраняться только выбранный язык или тема; форму связывает с бронированием защищённый токен в URL.",
         },
         {
           title: "Ваши права (GDPR)",
@@ -251,21 +251,21 @@ export const GUEST_UI_COPY: Record<GuestFormLocale, GuestUiCopy> = {
     privacy: {
       title: "Datenschutz & Datenverarbeitung",
       summary:
-        "Nur Ihr Gastgeber sieht Ihre Antworten. Gespeichert auf RentTools.io — Open-Source-Software, ausschließlich HTTPS, kein Tracking.",
+        "Verwendung nur für die gesetzlich erforderliche Gästeanmeldung und Aufenthaltsverwaltung — nicht für Marketing. Identitätsdaten werden verschlüsselt gespeichert und übertragen.",
       showDetails: "Details",
       hideDetails: "Ausblenden",
       bullets: [
         {
           title: "Wer sieht diese Angaben",
-          body: "Nur der Gastgeber der von Ihnen gebuchten Unterkunft. Ihre Antworten gehen direkt in dessen RentTools-Konto. Es findet keine Weitergabe, kein Verkauf und keine Verwendung für Werbung statt.",
+          body: "Der Gastgeber und ein ausdrücklich berechtigter Unterkunftsmanager. Reinigungskräfte und der RentTools-Support im Supportmodus erhalten keinen Zugriff auf die Identitätsdaten. Keine Verwendung für Werbung.",
         },
         {
           title: "Wo werden die Daten gespeichert",
-          body: "RentTools.io ist ein Open-Source-Werkzeug — der Quellcode ist öffentlich, jeder kann nachvollziehen, was mit Ihren Daten geschieht. Die Verbindung zu diesem Formular ist HTTPS-verschlüsselt.",
+          body: "Die Identitätsdaten werden vor der Speicherung in der Datenbank verschlüsselt. Auch die Verbindung zum Formular ist HTTPS-verschlüsselt. Ausweisbilder werden in diesem Formular nicht hochgeladen.",
         },
         {
           title: "Kein Tracking",
-          body: "Auf dieser Seite werden keine Analyse-Tools, keine Werbe-Cookies und keine Skripte Dritter geladen. Es wird nur das technisch notwendige Cookie gesetzt, um Ihre Antwort der Buchung zuzuordnen.",
+          body: "Auf dieser Seite werden keine Analyse-Tools oder Werbe-Cookies geladen. Nur eine gewählte Sprach- oder Darstellungspräferenz kann technisch gespeichert werden; die Zuordnung zur Reservierung erfolgt über den sicheren URL-Token.",
         },
         {
           title: "Ihre Rechte (DSGVO)",
@@ -293,21 +293,21 @@ export const GUEST_UI_COPY: Record<GuestFormLocale, GuestUiCopy> = {
     privacy: {
       title: "Confidentialité et traitement des données",
       summary:
-        "Seul votre hôte voit vos réponses. Stockées sur RentTools.io — logiciel open source, HTTPS uniquement, sans pistage.",
+        "Données utilisées pour l’enregistrement légal des voyageurs et la gestion du séjour, jamais à des fins marketing. Les données d’identité sont chiffrées au repos et en transit.",
       showDetails: "Détails",
       hideDetails: "Masquer",
       bullets: [
         {
           title: "Qui voit ces informations",
-          body: "Uniquement l'hôte du logement que vous avez réservé. Vos réponses sont transmises directement à son compte RentTools. Aucun partage, aucune vente, aucune utilisation à des fins publicitaires.",
+          body: "L’hôte et un gestionnaire du logement expressément autorisé. Le personnel de ménage et l’assistance RentTools en mode d’usurpation n’accèdent pas aux données d’identité. Aucune vente ni utilisation publicitaire.",
         },
         {
           title: "Où elles sont stockées",
-          body: "RentTools.io est un outil open source — le code source est public, ce qui permet à quiconque de vérifier ce qui est fait de vos données. La connexion à ce formulaire est chiffrée en HTTPS.",
+          body: "Les données d’identité sont chiffrées par l’application avant leur stockage en base. La connexion au formulaire est chiffrée en HTTPS. Le dépôt d’images de pièces d’identité est désactivé ici.",
         },
         {
           title: "Aucun pistage",
-          body: "Aucun outil d'analyse, aucun cookie publicitaire ni script tiers n'est chargé sur cette page. Seul le cookie strictement nécessaire pour relier votre réponse à votre réservation est utilisé.",
+          body: "Aucun outil d’analyse ni cookie publicitaire n’est chargé. Seule une préférence de langue ou d’affichage peut être mémorisée; le jeton sécurisé de l’URL relie le formulaire à la réservation.",
         },
         {
           title: "Vos droits (RGPD)",
@@ -335,21 +335,21 @@ export const GUEST_UI_COPY: Record<GuestFormLocale, GuestUiCopy> = {
     privacy: {
       title: "Privacidad y tratamiento de datos",
       summary:
-        "Solo su anfitrión ve sus respuestas. Almacenadas en RentTools.io — software de código abierto, solo HTTPS, sin rastreo.",
+        "Datos usados para el registro legal de huéspedes y la gestión de la estancia, no para marketing. Los datos de identidad se cifran en reposo y en tránsito.",
       showDetails: "Detalles",
       hideDetails: "Ocultar",
       bullets: [
         {
           title: "Quién ve estos datos",
-          body: "Solo el anfitrión del alojamiento que ha reservado. Sus respuestas llegan directamente a su cuenta de RentTools. No se comparten, no se venden y no se utilizan con fines publicitarios.",
+          body: "El anfitrión y un gestor del alojamiento autorizado expresamente. El personal de limpieza y el soporte de RentTools en modo de suplantación no acceden a los datos de identidad. No se venden ni se usan para publicidad.",
         },
         {
           title: "Dónde se almacenan",
-          body: "RentTools.io es una herramienta de código abierto — el código fuente es público, por lo que cualquiera puede verificar qué se hace con sus datos. La conexión con este formulario está cifrada por HTTPS.",
+          body: "Los datos de identidad se cifran en la aplicación antes de guardarlos en la base de datos. La conexión al formulario usa HTTPS. La carga de imágenes de documentos está desactivada aquí.",
         },
         {
           title: "Sin rastreo",
-          body: "En esta página no se carga ninguna herramienta de analítica, ninguna cookie publicitaria ni ningún script de terceros. Solo se usa la cookie estrictamente necesaria para vincular su respuesta con la reserva.",
+          body: "No se cargan herramientas de analítica ni cookies publicitarias. Solo puede guardarse una preferencia de idioma o apariencia; el token seguro de la URL vincula el formulario con la reserva.",
         },
         {
           title: "Sus derechos (RGPD)",

--- a/src/lib/guest-form-security.test.ts
+++ b/src/lib/guest-form-security.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/prisma", () => ({ prisma: {} }));
 
@@ -8,6 +8,13 @@ import {
   publicSubmissionState,
   sameOriginRequest,
 } from "@/lib/guest-form-security";
+
+const previousPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+afterEach(() => {
+  if (previousPublicAppUrl === undefined) delete process.env.PUBLIC_APP_URL;
+  else process.env.PUBLIC_APP_URL = previousPublicAppUrl;
+});
 
 describe("guest-form public-link security", () => {
   it("mints an opaque token and expires it after checkout", () => {
@@ -35,6 +42,36 @@ describe("guest-form public-link security", () => {
     }))).toBe(true);
     expect(sameOriginRequest(new Request("https://renttools.test/api/g/token/draft", {
       headers: { origin: "https://attacker.test" },
+    }))).toBe(false);
+    expect(sameOriginRequest(new Request("https://renttools.test/api/g/token/draft")))
+      .toBe(false);
+    expect(sameOriginRequest(new Request("https://renttools.test/api/g/token/draft", {
+      headers: { origin: "null" },
+    }))).toBe(false);
+  });
+
+  it("uses the configured public origin behind a reverse proxy", () => {
+    process.env.PUBLIC_APP_URL = "https://renttools.io";
+    const proxyUrl = "http://renttools-app:3000/api/g/token/draft";
+    expect(sameOriginRequest(new Request(proxyUrl, {
+      headers: {
+        origin: "https://renttools.io",
+        forwarded: "for=192.0.2.1;proto=https;host=renttools.io",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "renttools.io",
+      },
+    }))).toBe(true);
+  });
+
+  it("does not let forwarded host headers redefine the trusted origin", () => {
+    process.env.PUBLIC_APP_URL = "https://renttools.io";
+    expect(sameOriginRequest(new Request("http://renttools-app:3000/api/g/token/draft", {
+      headers: {
+        origin: "https://attacker.test",
+        forwarded: "for=192.0.2.1;proto=https;host=attacker.test",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "attacker.test",
+      },
     }))).toBe(false);
   });
 });

--- a/src/lib/guest-form-security.test.ts
+++ b/src/lib/guest-form-security.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({ prisma: {} }));
+
+import {
+  guestFormExpiry,
+  mintGuestFormToken,
+  publicSubmissionState,
+  sameOriginRequest,
+} from "@/lib/guest-form-security";
+
+describe("guest-form public-link security", () => {
+  it("mints an opaque token and expires it after checkout", () => {
+    const token = mintGuestFormToken();
+    expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(token).not.toMatch(/^\d+$/);
+    expect(guestFormExpiry(new Date("2027-05-28T00:00:00.000Z")).toISOString())
+      .toBe("2027-05-29T23:59:59.999Z");
+  });
+
+  it("fails closed for revoked, expired and submitted links", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-05-20T12:00:00.000Z"));
+    const base = { revokedAt: null, expiresAt: null, submittedAt: null, status: "INVITED" };
+    expect(publicSubmissionState(base)).toBe("active");
+    expect(publicSubmissionState({ ...base, revokedAt: new Date() })).toBe("revoked");
+    expect(publicSubmissionState({ ...base, expiresAt: new Date("2027-05-19") })).toBe("expired");
+    expect(publicSubmissionState({ ...base, submittedAt: new Date() })).toBe("submitted");
+    vi.useRealTimers();
+  });
+
+  it("rejects cross-origin writes", () => {
+    expect(sameOriginRequest(new Request("https://renttools.test/api/g/token/draft", {
+      headers: { origin: "https://renttools.test" },
+    }))).toBe(true);
+    expect(sameOriginRequest(new Request("https://renttools.test/api/g/token/draft", {
+      headers: { origin: "https://attacker.test" },
+    }))).toBe(false);
+  });
+});

--- a/src/lib/guest-form-security.ts
+++ b/src/lib/guest-form-security.ts
@@ -1,0 +1,75 @@
+import { randomBytes } from "node:crypto";
+import { prisma } from "@/lib/prisma";
+import { decryptGuestData, hashShareToken } from "@/lib/precheckin-crypto";
+
+export function mintGuestFormToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function guestFormExpiry(checkOut: Date): Date {
+  const expiry = new Date(checkOut);
+  expiry.setUTCDate(expiry.getUTCDate() + 1);
+  expiry.setUTCHours(23, 59, 59, 999);
+  return expiry;
+}
+
+export async function findSubmissionByPublicToken(token: string) {
+  if (!token || token.length < 32 || token.length > 180) return null;
+  const tokenHash = hashShareToken(token);
+  const hardened = await prisma.guestFormSubmission.findUnique({
+    where: { tokenHash },
+    include: {
+      template: true,
+      reservation: {
+        include: { property: { select: { id: true, name: true, feedToken: true } } },
+      },
+    },
+  });
+  if (hardened) return hardened;
+
+  // Existing links issued before token hashing remain usable until their owner
+  // rotates or revokes them. New links never enter this fallback path.
+  return prisma.guestFormSubmission.findUnique({
+    where: { shareToken: token },
+    include: {
+      template: true,
+      reservation: {
+        include: { property: { select: { id: true, name: true, feedToken: true } } },
+      },
+    },
+  });
+}
+
+export function publicSubmissionState(submission: {
+  revokedAt: Date | null;
+  expiresAt: Date | null;
+  submittedAt: Date | null;
+  status: string;
+}): "active" | "revoked" | "expired" | "submitted" {
+  if (submission.revokedAt || submission.status === "REVOKED") return "revoked";
+  if (submission.expiresAt && submission.expiresAt.getTime() < Date.now()) return "expired";
+  if (submission.submittedAt || submission.status === "OWNER_REVIEW_REQUIRED" || submission.status === "OWNER_APPROVED") {
+    return "submitted";
+  }
+  return "active";
+}
+
+export function decryptOwnerShareToken(tokenCiphertext: string | null): string | null {
+  if (!tokenCiphertext) return null;
+  try {
+    const value = decryptGuestData<{ token: string }>(tokenCiphertext);
+    return typeof value.token === "string" ? value.token : null;
+  } catch {
+    return null;
+  }
+}
+
+export function sameOriginRequest(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return true;
+  try {
+    return new URL(origin).host === new URL(request.url).host;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/guest-form-security.ts
+++ b/src/lib/guest-form-security.ts
@@ -66,9 +66,24 @@ export function decryptOwnerShareToken(tokenCiphertext: string | null): string |
 
 export function sameOriginRequest(request: Request): boolean {
   const origin = request.headers.get("origin");
-  if (!origin) return true;
+  // Browser writes to a bearer-token URL must carry an Origin header. A
+  // missing/opaque origin is not treated as same-origin: accepting it would
+  // make the protection disappear for malformed proxy traffic and non-browser
+  // replays.
+  if (!origin || origin === "null") return false;
   try {
-    return new URL(origin).host === new URL(request.url).host;
+    const received = new URL(origin);
+    const configured = process.env.PUBLIC_APP_URL?.trim();
+    const expected = configured ? new URL(configured) : new URL(request.url);
+
+    // Production needs a stable canonical origin. Deriving trust from Host or
+    // X-Forwarded-Host lets a client-controlled header redefine "same site".
+    if (process.env.NODE_ENV === "production") {
+      if (!configured || expected.protocol !== "https:" || received.protocol !== "https:") {
+        return false;
+      }
+    }
+    return received.origin === expected.origin;
   } catch {
     return false;
   }

--- a/src/lib/precheckin-crypto.test.ts
+++ b/src/lib/precheckin-crypto.test.ts
@@ -7,11 +7,21 @@ import {
   maskDocumentNumber,
 } from "@/lib/precheckin-crypto";
 
-const previousKey = process.env.GUEST_DATA_ENCRYPTION_KEY;
+const previousEnvironment = {
+  key: process.env.GUEST_DATA_ENCRYPTION_KEY,
+  version: process.env.GUEST_DATA_ENCRYPTION_KEY_VERSION,
+  previousKeys: process.env.GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS,
+};
 
 afterEach(() => {
-  if (previousKey === undefined) delete process.env.GUEST_DATA_ENCRYPTION_KEY;
-  else process.env.GUEST_DATA_ENCRYPTION_KEY = previousKey;
+  for (const [name, value] of [
+    ["GUEST_DATA_ENCRYPTION_KEY", previousEnvironment.key],
+    ["GUEST_DATA_ENCRYPTION_KEY_VERSION", previousEnvironment.version],
+    ["GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS", previousEnvironment.previousKeys],
+  ] as const) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
 });
 
 describe("precheckin encryption", () => {
@@ -26,6 +36,30 @@ describe("precheckin encryption", () => {
     const encrypted = encryptGuestData({ passport: "ABC123" });
     expect(encrypted).not.toContain("ABC123");
     expect(decryptGuestData(encrypted)).toEqual({ passport: "ABC123" });
+  });
+
+  it("reads v1 after rotating writes to v2", () => {
+    const v1Key = "11".repeat(32);
+    const v2Key = "22".repeat(32);
+    process.env.GUEST_DATA_ENCRYPTION_KEY = v1Key;
+    const legacy = encryptGuestData({ passport: "LEGACY" });
+    expect(legacy.startsWith("v1.")).toBe(true);
+
+    process.env.GUEST_DATA_ENCRYPTION_KEY_VERSION = "v2";
+    process.env.GUEST_DATA_ENCRYPTION_KEY = v2Key;
+    process.env.GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS = JSON.stringify({ v1: v1Key });
+
+    const current = encryptGuestData({ passport: "CURRENT" });
+    expect(current.startsWith("v2.")).toBe(true);
+    expect(decryptGuestData(legacy)).toEqual({ passport: "LEGACY" });
+    expect(decryptGuestData(current)).toEqual({ passport: "CURRENT" });
+  });
+
+  it("fails closed for an unknown payload version", () => {
+    process.env.GUEST_DATA_ENCRYPTION_KEY_VERSION = "v2";
+    process.env.GUEST_DATA_ENCRYPTION_KEY = "22".repeat(32);
+    expect(() => decryptGuestData("v9.AAAAAAAAAAAAAAAA.AAAAAAAAAAAAAAAAAAAAAA.AA"))
+      .toThrow(/not configured/);
   });
 
   it("hashes share tokens and masks documents", () => {

--- a/src/lib/precheckin-crypto.test.ts
+++ b/src/lib/precheckin-crypto.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  decryptGuestData,
+  encryptGuestData,
+  guestDataEncryptionReady,
+  hashShareToken,
+  maskDocumentNumber,
+} from "@/lib/precheckin-crypto";
+
+const previousKey = process.env.GUEST_DATA_ENCRYPTION_KEY;
+
+afterEach(() => {
+  if (previousKey === undefined) delete process.env.GUEST_DATA_ENCRYPTION_KEY;
+  else process.env.GUEST_DATA_ENCRYPTION_KEY = previousKey;
+});
+
+describe("precheckin encryption", () => {
+  it("fails closed without a key", () => {
+    delete process.env.GUEST_DATA_ENCRYPTION_KEY;
+    expect(guestDataEncryptionReady()).toBe(false);
+    expect(() => encryptGuestData({ passport: "ABC123" })).toThrow(/not configured/);
+  });
+
+  it("round-trips authenticated encrypted JSON", () => {
+    process.env.GUEST_DATA_ENCRYPTION_KEY = "11".repeat(32);
+    const encrypted = encryptGuestData({ passport: "ABC123" });
+    expect(encrypted).not.toContain("ABC123");
+    expect(decryptGuestData(encrypted)).toEqual({ passport: "ABC123" });
+  });
+
+  it("hashes share tokens and masks documents", () => {
+    expect(hashShareToken("secret")).toHaveLength(64);
+    expect(maskDocumentNumber("ABCD123456")).toBe("••••••3456");
+    expect(maskDocumentNumber("1234")).toBe("••••");
+  });
+});

--- a/src/lib/precheckin-crypto.ts
+++ b/src/lib/precheckin-crypto.ts
@@ -1,20 +1,73 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 
-const VERSION = "v1";
+const DEFAULT_VERSION = "v1";
+const VERSION_PATTERN = /^v[1-9][0-9]*$/;
 
-function keyFromEnvironment(): Buffer {
-  const raw = process.env.GUEST_DATA_ENCRYPTION_KEY?.trim();
-  if (!raw) throw new Error("GUEST_DATA_ENCRYPTION_KEY is not configured");
+function decodeKey(raw: string, label: string): Buffer {
   const key = /^[0-9a-f]{64}$/i.test(raw)
     ? Buffer.from(raw, "hex")
     : Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64");
-  if (key.length !== 32) throw new Error("GUEST_DATA_ENCRYPTION_KEY must decode to 32 bytes");
+  if (key.length !== 32) throw new Error(`${label} must decode to 32 bytes`);
+  return key;
+}
+
+function currentVersion(): string {
+  const version = process.env.GUEST_DATA_ENCRYPTION_KEY_VERSION?.trim() || DEFAULT_VERSION;
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error("GUEST_DATA_ENCRYPTION_KEY_VERSION must be v1, v2, ...");
+  }
+  return version;
+}
+
+function currentKey(): Buffer {
+  const raw = process.env.GUEST_DATA_ENCRYPTION_KEY?.trim();
+  if (!raw) throw new Error("GUEST_DATA_ENCRYPTION_KEY is not configured");
+  return decodeKey(raw, "GUEST_DATA_ENCRYPTION_KEY");
+}
+
+function previousKeys(): Map<string, Buffer> {
+  const raw = process.env.GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS?.trim();
+  if (!raw) return new Map();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS must be a JSON object");
+  }
+  if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+    throw new Error("GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS must be a JSON object");
+  }
+
+  const current = currentVersion();
+  const result = new Map<string, Buffer>();
+  for (const [version, value] of Object.entries(parsed)) {
+    if (!VERSION_PATTERN.test(version) || typeof value !== "string" || !value.trim()) {
+      throw new Error("GUEST_DATA_ENCRYPTION_PREVIOUS_KEYS contains an invalid entry");
+    }
+    if (version === current) {
+      throw new Error("The current guest-data key version must not also be configured as a previous key");
+    }
+    result.set(version, decodeKey(value.trim(), `Guest-data key ${version}`));
+  }
+  return result;
+}
+
+function keyForVersion(version: string): Buffer {
+  if (!VERSION_PATTERN.test(version)) {
+    throw new Error("Unsupported encrypted guest-data payload");
+  }
+  if (version === currentVersion()) return currentKey();
+  const key = previousKeys().get(version);
+  if (!key) throw new Error(`Guest-data key ${version} is not configured`);
   return key;
 }
 
 export function guestDataEncryptionReady(): boolean {
   try {
-    keyFromEnvironment();
+    currentVersion();
+    currentKey();
+    previousKeys();
     return true;
   } catch {
     return false;
@@ -26,20 +79,21 @@ export function hashShareToken(token: string): string {
 }
 
 export function encryptGuestData(value: unknown): string {
+  const version = currentVersion();
   const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", keyFromEnvironment(), iv);
+  const cipher = createCipheriv("aes-256-gcm", currentKey(), iv);
   const plaintext = Buffer.from(JSON.stringify(value), "utf8");
   const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
   const tag = cipher.getAuthTag();
-  return [VERSION, iv.toString("base64url"), tag.toString("base64url"), ciphertext.toString("base64url")].join(".");
+  return [version, iv.toString("base64url"), tag.toString("base64url"), ciphertext.toString("base64url")].join(".");
 }
 
 export function decryptGuestData<T>(encrypted: string): T {
   const [version, ivPart, tagPart, ciphertextPart] = encrypted.split(".");
-  if (version !== VERSION || !ivPart || !tagPart || !ciphertextPart) {
+  if (!version || !ivPart || !tagPart || !ciphertextPart || encrypted.split(".").length !== 4) {
     throw new Error("Unsupported encrypted guest-data payload");
   }
-  const decipher = createDecipheriv("aes-256-gcm", keyFromEnvironment(), Buffer.from(ivPart, "base64url"));
+  const decipher = createDecipheriv("aes-256-gcm", keyForVersion(version), Buffer.from(ivPart, "base64url"));
   decipher.setAuthTag(Buffer.from(tagPart, "base64url"));
   const plaintext = Buffer.concat([
     decipher.update(Buffer.from(ciphertextPart, "base64url")),

--- a/src/lib/precheckin-crypto.ts
+++ b/src/lib/precheckin-crypto.ts
@@ -1,0 +1,54 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
+
+const VERSION = "v1";
+
+function keyFromEnvironment(): Buffer {
+  const raw = process.env.GUEST_DATA_ENCRYPTION_KEY?.trim();
+  if (!raw) throw new Error("GUEST_DATA_ENCRYPTION_KEY is not configured");
+  const key = /^[0-9a-f]{64}$/i.test(raw)
+    ? Buffer.from(raw, "hex")
+    : Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+  if (key.length !== 32) throw new Error("GUEST_DATA_ENCRYPTION_KEY must decode to 32 bytes");
+  return key;
+}
+
+export function guestDataEncryptionReady(): boolean {
+  try {
+    keyFromEnvironment();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hashShareToken(token: string): string {
+  return createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+export function encryptGuestData(value: unknown): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", keyFromEnvironment(), iv);
+  const plaintext = Buffer.from(JSON.stringify(value), "utf8");
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [VERSION, iv.toString("base64url"), tag.toString("base64url"), ciphertext.toString("base64url")].join(".");
+}
+
+export function decryptGuestData<T>(encrypted: string): T {
+  const [version, ivPart, tagPart, ciphertextPart] = encrypted.split(".");
+  if (version !== VERSION || !ivPart || !tagPart || !ciphertextPart) {
+    throw new Error("Unsupported encrypted guest-data payload");
+  }
+  const decipher = createDecipheriv("aes-256-gcm", keyFromEnvironment(), Buffer.from(ivPart, "base64url"));
+  decipher.setAuthTag(Buffer.from(tagPart, "base64url"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(ciphertextPart, "base64url")),
+    decipher.final(),
+  ]);
+  return JSON.parse(plaintext.toString("utf8")) as T;
+}
+
+export function maskDocumentNumber(value: string): string {
+  if (value.length <= 4) return "••••";
+  return `${"•".repeat(Math.min(8, value.length - 4))}${value.slice(-4)}`;
+}

--- a/src/lib/precheckin.test.ts
+++ b/src/lib/precheckin.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  ageOnDate,
+  precheckinWarnings,
+  requiresNonEuBorderFields,
+  suggestTaxCategory,
+  validatePrecheckinPayload,
+} from "@/lib/precheckin";
+
+const traveler = {
+  clientId: "lead-1",
+  isLead: true,
+  firstName: "Ana",
+  lastName: "Horvat",
+  dateOfBirth: "1990-05-20",
+  gender: "F",
+  citizenshipCountry: "HR",
+  birthCountry: "HR",
+  birthPlace: "Zagreb",
+  residenceCountry: "HR",
+  residencePlace: "Zagreb",
+  residenceAddress: "Example 1",
+  documentType: "IDENTITY_CARD",
+  documentNumber: "ABC123",
+};
+
+function payload(travelers = [traveler]) {
+  return {
+    expectedArrivalTime: "16:30",
+    arrivalOrganization: "INDIVIDUAL",
+    serviceType: "ACCOMMODATION",
+    travelers,
+    customAnswers: [],
+  };
+}
+
+describe("precheckin validation", () => {
+  it("accepts one complete traveler and derives the adult category", () => {
+    const result = validatePrecheckinPayload(payload(), {
+      checkIn: "2027-05-16",
+      checkOut: "2027-05-28",
+      maxTravelers: 6,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.payload?.travelers[0].taxCategorySuggestion).toBe("STANDARD_ADULT");
+  });
+
+  it("rejects duplicate travelers and more than one lead", () => {
+    const result = validatePrecheckinPayload(payload([traveler, { ...traveler, clientId: "two" }]), {
+      checkIn: "2027-05-16",
+      checkOut: "2027-05-28",
+      maxTravelers: 6,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join(" ")).toMatch(/Exactly one lead|duplicate traveler/);
+  });
+
+  it("enforces the configured traveler limit", () => {
+    const travelers = Array.from({ length: 7 }, (_, index) => ({
+      ...traveler,
+      clientId: String(index),
+      isLead: index === 0,
+      firstName: `Guest${index}`,
+      documentNumber: `DOC${index}`,
+    }));
+    const result = validatePrecheckinPayload(payload(travelers), {
+      checkIn: "2027-05-16",
+      checkOut: "2027-05-28",
+      maxTravelers: 6,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain("Traveler count exceeds reservation limit (6)");
+  });
+
+  it("flags missing non-EU border data without inventing it", () => {
+    const result = validatePrecheckinPayload(payload([{ ...traveler, citizenshipCountry: "US" }]), {
+      checkIn: "2027-05-16",
+      checkOut: "2027-05-28",
+    });
+    expect(result.ok).toBe(true);
+    expect(precheckinWarnings(result.payload!)).toHaveLength(1);
+    expect(requiresNonEuBorderFields("US")).toBe(true);
+    expect(requiresNonEuBorderFields("HR")).toBe(false);
+  });
+});
+
+describe("age and tax-category suggestions", () => {
+  it("handles birthdays at the reference date boundary", () => {
+    expect(ageOnDate("2015-05-17", "2027-05-16")).toBe(11);
+    expect(ageOnDate("2015-05-16", "2027-05-16")).toBe(12);
+  });
+
+  it("suggests under-12, reduced, and adult categories", () => {
+    expect(suggestTaxCategory("2016-01-01", "2027-05-16")).toBe("EXEMPT_UNDER_12");
+    expect(suggestTaxCategory("2011-01-01", "2027-05-16")).toBe("REDUCED_12_TO_17");
+    expect(suggestTaxCategory("1990-01-01", "2027-05-16")).toBe("STANDARD_ADULT");
+  });
+});

--- a/src/lib/precheckin.test.ts
+++ b/src/lib/precheckin.test.ts
@@ -73,7 +73,11 @@ describe("precheckin validation", () => {
   });
 
   it("flags missing non-EU border data without inventing it", () => {
-    const result = validatePrecheckinPayload(payload([{ ...traveler, citizenshipCountry: "US" }]), {
+    const result = validatePrecheckinPayload(payload([{
+      ...traveler,
+      citizenshipCountry: "HR",
+      residenceCountry: "US",
+    }]), {
       checkIn: "2027-05-16",
       checkOut: "2027-05-28",
     });

--- a/src/lib/precheckin.ts
+++ b/src/lib/precheckin.ts
@@ -1,0 +1,310 @@
+export const PRECHECKIN_STATUSES = [
+  "NOT_INVITED",
+  "INVITED",
+  "IN_PROGRESS",
+  "COMPLETE",
+  "OWNER_REVIEW_REQUIRED",
+  "OWNER_APPROVED",
+  "REVOKED",
+] as const;
+
+export type PrecheckinStatus = (typeof PRECHECKIN_STATUSES)[number];
+
+export const DOCUMENT_TYPES = ["PASSPORT", "IDENTITY_CARD", "OTHER"] as const;
+export type DocumentType = (typeof DOCUMENT_TYPES)[number];
+
+export const GENDERS = ["M", "F", "X", "UNSPECIFIED"] as const;
+export type TravelerGender = (typeof GENDERS)[number];
+
+export const ARRIVAL_ORGANIZATIONS = [
+  "INDIVIDUAL",
+  "TRAVEL_AGENCY",
+  "TOUR_OPERATOR",
+  "OTHER",
+] as const;
+
+export const SERVICE_TYPES = ["ACCOMMODATION", "OTHER"] as const;
+
+// ISO 3166-1 alpha-2. Keeping the accepted values in code makes the public
+// endpoint fail closed instead of accepting arbitrary country text that later
+// cannot be mapped to eVisitor.
+const ISO_COUNTRY_CODES = `AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ VA VC VE VG VI VN VU WF WS YE YT ZA ZM ZW`;
+
+export const COUNTRY_CODES = ISO_COUNTRY_CODES.split(" ");
+const COUNTRY_CODE_SET = new Set(COUNTRY_CODES);
+
+const EU_COUNTRY_CODES = new Set(
+  "AT BE BG HR CY CZ DK EE FI FR DE GR HU IE IT LV LT LU MT NL PL PT RO SK SI ES SE".split(" "),
+);
+
+export interface PrecheckinTraveler {
+  clientId: string;
+  isLead: boolean;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  gender: TravelerGender;
+  citizenshipCountry: string;
+  birthCountry: string;
+  birthPlace: string;
+  residenceCountry: string;
+  residencePlace: string;
+  residenceAddress: string;
+  documentType: DocumentType;
+  documentNumber: string;
+  borderEntryDate?: string;
+  borderEntryPlace?: string;
+  borderEntryPoint?: string;
+  taxCategorySuggestion?: "EXEMPT_UNDER_12" | "REDUCED_12_TO_17" | "STANDARD_ADULT";
+}
+
+export interface PrecheckinPayload {
+  version: 1;
+  expectedArrivalDate: string;
+  expectedDepartureDate: string;
+  expectedArrivalTime: string;
+  arrivalOrganization: (typeof ARRIVAL_ORGANIZATIONS)[number];
+  serviceType: (typeof SERVICE_TYPES)[number];
+  travelers: PrecheckinTraveler[];
+  customAnswers: Array<{
+    fieldId: string;
+    type: string;
+    label: string;
+    value: unknown;
+  }>;
+}
+
+export interface PrecheckinDraft {
+  expectedArrivalTime: string;
+  arrivalOrganization: string;
+  serviceType: string;
+  travelers: Array<Record<string, unknown>>;
+  customAnswers: Array<{ fieldId: string; value: unknown }>;
+}
+
+export interface PrecheckinValidationOptions {
+  checkIn: string;
+  checkOut: string;
+  maxTravelers?: number | null;
+}
+
+export interface PrecheckinValidationResult {
+  ok: boolean;
+  errors: string[];
+  payload?: PrecheckinPayload;
+}
+
+function isIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+export function ageOnDate(dateOfBirth: string, referenceDate: string): number | null {
+  if (!isIsoDate(dateOfBirth) || !isIsoDate(referenceDate)) return null;
+  const birth = new Date(`${dateOfBirth}T00:00:00Z`);
+  const reference = new Date(`${referenceDate}T00:00:00Z`);
+  let age = reference.getUTCFullYear() - birth.getUTCFullYear();
+  const monthDelta = reference.getUTCMonth() - birth.getUTCMonth();
+  if (monthDelta < 0 || (monthDelta === 0 && reference.getUTCDate() < birth.getUTCDate())) {
+    age -= 1;
+  }
+  return age;
+}
+
+export function suggestTaxCategory(
+  dateOfBirth: string,
+  referenceDate: string,
+): PrecheckinTraveler["taxCategorySuggestion"] | null {
+  const age = ageOnDate(dateOfBirth, referenceDate);
+  if (age === null || age < 0) return null;
+  if (age < 12) return "EXEMPT_UNDER_12";
+  if (age < 18) return "REDUCED_12_TO_17";
+  return "STANDARD_ADULT";
+}
+
+export function requiresNonEuBorderFields(citizenshipCountry: string): boolean {
+  return COUNTRY_CODE_SET.has(citizenshipCountry) && !EU_COUNTRY_CODES.has(citizenshipCountry);
+}
+
+function normalizeTraveler(raw: unknown, checkIn: string): PrecheckinTraveler | null {
+  if (!raw || typeof raw !== "object") return null;
+  const input = raw as Record<string, unknown>;
+  const string = (key: string) => (typeof input[key] === "string" ? input[key].trim() : "");
+  const citizenshipCountry = string("citizenshipCountry").toUpperCase();
+  const traveler: PrecheckinTraveler = {
+    clientId: string("clientId").slice(0, 80),
+    isLead: input.isLead === true,
+    firstName: string("firstName").slice(0, 120),
+    lastName: string("lastName").slice(0, 120),
+    dateOfBirth: string("dateOfBirth"),
+    gender: string("gender") as TravelerGender,
+    citizenshipCountry,
+    birthCountry: string("birthCountry").toUpperCase(),
+    birthPlace: string("birthPlace").slice(0, 160),
+    residenceCountry: string("residenceCountry").toUpperCase(),
+    residencePlace: string("residencePlace").slice(0, 160),
+    residenceAddress: string("residenceAddress").slice(0, 240),
+    documentType: string("documentType") as DocumentType,
+    documentNumber: string("documentNumber").replace(/\s+/g, "").slice(0, 80),
+    taxCategorySuggestion: suggestTaxCategory(string("dateOfBirth"), checkIn) ?? undefined,
+  };
+  if (requiresNonEuBorderFields(citizenshipCountry)) {
+    traveler.borderEntryDate = string("borderEntryDate");
+    traveler.borderEntryPlace = string("borderEntryPlace").slice(0, 160);
+    traveler.borderEntryPoint = string("borderEntryPoint").slice(0, 160);
+  }
+  return traveler;
+}
+
+/**
+ * Bound and normalise an unfinished browser draft before encrypting it. This is
+ * deliberately less strict than final validation, but it never stores unknown
+ * top-level objects or an unbounded request body.
+ */
+export function sanitizePrecheckinDraft(raw: unknown): PrecheckinDraft {
+  if (!raw || typeof raw !== "object") {
+    return { expectedArrivalTime: "", arrivalOrganization: "", serviceType: "", travelers: [], customAnswers: [] };
+  }
+  const input = raw as Record<string, unknown>;
+  const travelers = Array.isArray(input.travelers)
+    ? input.travelers.slice(0, 50).map((entry) => {
+        const traveler = entry && typeof entry === "object" ? entry as Record<string, unknown> : {};
+        const keep = [
+          "clientId", "isLead", "firstName", "lastName", "dateOfBirth", "gender",
+          "citizenshipCountry", "birthCountry", "birthPlace", "residenceCountry",
+          "residencePlace", "residenceAddress", "documentType", "documentNumber",
+          "borderEntryDate", "borderEntryPlace", "borderEntryPoint",
+        ];
+        return Object.fromEntries(keep.map((key) => {
+          const value = traveler[key];
+          return [key, typeof value === "string" ? value.slice(0, 240) : value === true];
+        }));
+      })
+    : [];
+  const customAnswers = Array.isArray(input.customAnswers)
+    ? input.customAnswers.slice(0, 100).flatMap((entry) => {
+        if (!entry || typeof entry !== "object") return [];
+        const answer = entry as Record<string, unknown>;
+        if (typeof answer.fieldId !== "string") return [];
+        let value = answer.value;
+        if (typeof value === "string") value = value.slice(0, 4000);
+        else if (Array.isArray(value)) value = value.slice(0, 50).map((item) => String(item).slice(0, 500));
+        else if (typeof value !== "number" && typeof value !== "boolean" && value !== null) value = null;
+        return [{ fieldId: answer.fieldId.slice(0, 100), value }];
+      })
+    : [];
+  return {
+    expectedArrivalTime: typeof input.expectedArrivalTime === "string" ? input.expectedArrivalTime.slice(0, 5) : "",
+    arrivalOrganization: typeof input.arrivalOrganization === "string" ? input.arrivalOrganization.slice(0, 40) : "",
+    serviceType: typeof input.serviceType === "string" ? input.serviceType.slice(0, 40) : "",
+    travelers,
+    customAnswers,
+  };
+}
+
+export function validatePrecheckinPayload(
+  raw: unknown,
+  options: PrecheckinValidationOptions,
+): PrecheckinValidationResult {
+  const errors: string[] = [];
+  if (!raw || typeof raw !== "object") return { ok: false, errors: ["Invalid payload"] };
+  const input = raw as Record<string, unknown>;
+  const rawTravelers = Array.isArray(input.travelers) ? input.travelers : [];
+  if (rawTravelers.length === 0) errors.push("At least one traveler is required");
+  if (options.maxTravelers && rawTravelers.length > options.maxTravelers) {
+    errors.push(`Traveler count exceeds reservation limit (${options.maxTravelers})`);
+  }
+  if (rawTravelers.length > 50) errors.push("Traveler count exceeds safety limit");
+
+  const travelers = rawTravelers
+    .map((traveler) => normalizeTraveler(traveler, options.checkIn))
+    .filter((traveler): traveler is PrecheckinTraveler => traveler !== null);
+  if (travelers.length !== rawTravelers.length) errors.push("Invalid traveler entry");
+  if (travelers.filter((traveler) => traveler.isLead).length !== 1) {
+    errors.push("Exactly one lead traveler is required");
+  }
+
+  const duplicateKeys = new Set<string>();
+  for (const [index, traveler] of travelers.entries()) {
+    const prefix = `Traveler ${index + 1}`;
+    if (!traveler.clientId) errors.push(`${prefix}: missing client id`);
+    if (!traveler.firstName) errors.push(`${prefix}: first name is required`);
+    if (!traveler.lastName) errors.push(`${prefix}: last name is required`);
+    if (!isIsoDate(traveler.dateOfBirth) || traveler.dateOfBirth >= options.checkIn) {
+      errors.push(`${prefix}: invalid date of birth`);
+    }
+    if (!GENDERS.includes(traveler.gender)) errors.push(`${prefix}: invalid gender`);
+    for (const [label, code] of [
+      ["citizenship", traveler.citizenshipCountry],
+      ["birth country", traveler.birthCountry],
+      ["residence country", traveler.residenceCountry],
+    ] as const) {
+      if (!COUNTRY_CODE_SET.has(code)) errors.push(`${prefix}: invalid ${label}`);
+    }
+    if (!traveler.birthPlace) errors.push(`${prefix}: birth place is required`);
+    if (!traveler.residencePlace) errors.push(`${prefix}: residence place is required`);
+    if (!traveler.residenceAddress) errors.push(`${prefix}: residence address is required`);
+    if (!DOCUMENT_TYPES.includes(traveler.documentType)) errors.push(`${prefix}: invalid document type`);
+    if (traveler.documentNumber.length < 2) errors.push(`${prefix}: document number is required`);
+
+    if (requiresNonEuBorderFields(traveler.citizenshipCountry)) {
+      if (traveler.borderEntryDate && !isIsoDate(traveler.borderEntryDate)) {
+        errors.push(`${prefix}: invalid border entry date`);
+      }
+    }
+
+    const duplicateKey = `${traveler.firstName.toLowerCase()}|${traveler.lastName.toLowerCase()}|${traveler.dateOfBirth}|${traveler.documentNumber.toLowerCase()}`;
+    if (duplicateKeys.has(duplicateKey)) errors.push(`${prefix}: duplicate traveler`);
+    duplicateKeys.add(duplicateKey);
+  }
+
+  const expectedArrivalTime = typeof input.expectedArrivalTime === "string"
+    ? input.expectedArrivalTime.trim()
+    : "";
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(expectedArrivalTime)) {
+    errors.push("Expected arrival time is required");
+  }
+  const arrivalOrganization = typeof input.arrivalOrganization === "string"
+    ? input.arrivalOrganization
+    : "";
+  if (!ARRIVAL_ORGANIZATIONS.includes(arrivalOrganization as never)) {
+    errors.push("Invalid arrival organization");
+  }
+  const serviceType = typeof input.serviceType === "string" ? input.serviceType : "";
+  if (!SERVICE_TYPES.includes(serviceType as never)) errors.push("Invalid service type");
+
+  const customAnswers = Array.isArray(input.customAnswers)
+    ? input.customAnswers.filter((answer): answer is PrecheckinPayload["customAnswers"][number] =>
+        !!answer && typeof answer === "object" && typeof (answer as { fieldId?: unknown }).fieldId === "string",
+      )
+    : [];
+
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    errors: [],
+    payload: {
+      version: 1,
+      expectedArrivalDate: options.checkIn,
+      expectedDepartureDate: options.checkOut,
+      expectedArrivalTime,
+      arrivalOrganization: arrivalOrganization as PrecheckinPayload["arrivalOrganization"],
+      serviceType: serviceType as PrecheckinPayload["serviceType"],
+      travelers,
+      customAnswers,
+    },
+  };
+}
+
+export function precheckinWarnings(payload: PrecheckinPayload): string[] {
+  const warnings: string[] = [];
+  for (const traveler of payload.travelers) {
+    if (requiresNonEuBorderFields(traveler.citizenshipCountry)) {
+      if (!traveler.borderEntryDate || !traveler.borderEntryPlace || !traveler.borderEntryPoint) {
+        warnings.push(`${traveler.firstName} ${traveler.lastName}: non-EU border data incomplete`);
+      }
+    }
+  }
+  return warnings;
+}

--- a/src/lib/precheckin.ts
+++ b/src/lib/precheckin.ts
@@ -38,6 +38,9 @@ const EU_COUNTRY_CODES = new Set(
 );
 
 export interface PrecheckinTraveler {
+  /** Server-issued stable ID. It is added only at final submission and is
+   * never accepted from the public draft as an authority value. */
+  guestId?: string;
   clientId: string;
   isLead: boolean;
   firstName: string;
@@ -123,8 +126,10 @@ export function suggestTaxCategory(
   return "STANDARD_ADULT";
 }
 
-export function requiresNonEuBorderFields(citizenshipCountry: string): boolean {
-  return COUNTRY_CODE_SET.has(citizenshipCountry) && !EU_COUNTRY_CODES.has(citizenshipCountry);
+export function requiresNonEuBorderFields(residenceCountry: string): boolean {
+  // eVisitor's CheckInTourist validation keys this requirement to the
+  // tourist's country of residence, not citizenship.
+  return COUNTRY_CODE_SET.has(residenceCountry) && !EU_COUNTRY_CODES.has(residenceCountry);
 }
 
 function normalizeTraveler(raw: unknown, checkIn: string): PrecheckinTraveler | null {
@@ -132,6 +137,7 @@ function normalizeTraveler(raw: unknown, checkIn: string): PrecheckinTraveler | 
   const input = raw as Record<string, unknown>;
   const string = (key: string) => (typeof input[key] === "string" ? input[key].trim() : "");
   const citizenshipCountry = string("citizenshipCountry").toUpperCase();
+  const residenceCountry = string("residenceCountry").toUpperCase();
   const traveler: PrecheckinTraveler = {
     clientId: string("clientId").slice(0, 80),
     isLead: input.isLead === true,
@@ -142,14 +148,14 @@ function normalizeTraveler(raw: unknown, checkIn: string): PrecheckinTraveler | 
     citizenshipCountry,
     birthCountry: string("birthCountry").toUpperCase(),
     birthPlace: string("birthPlace").slice(0, 160),
-    residenceCountry: string("residenceCountry").toUpperCase(),
+    residenceCountry,
     residencePlace: string("residencePlace").slice(0, 160),
     residenceAddress: string("residenceAddress").slice(0, 240),
     documentType: string("documentType") as DocumentType,
     documentNumber: string("documentNumber").replace(/\s+/g, "").slice(0, 80),
     taxCategorySuggestion: suggestTaxCategory(string("dateOfBirth"), checkIn) ?? undefined,
   };
-  if (requiresNonEuBorderFields(citizenshipCountry)) {
+  if (requiresNonEuBorderFields(residenceCountry)) {
     traveler.borderEntryDate = string("borderEntryDate");
     traveler.borderEntryPlace = string("borderEntryPlace").slice(0, 160);
     traveler.borderEntryPoint = string("borderEntryPoint").slice(0, 160);
@@ -248,7 +254,7 @@ export function validatePrecheckinPayload(
     if (!DOCUMENT_TYPES.includes(traveler.documentType)) errors.push(`${prefix}: invalid document type`);
     if (traveler.documentNumber.length < 2) errors.push(`${prefix}: document number is required`);
 
-    if (requiresNonEuBorderFields(traveler.citizenshipCountry)) {
+    if (requiresNonEuBorderFields(traveler.residenceCountry)) {
       if (traveler.borderEntryDate && !isIsoDate(traveler.borderEntryDate)) {
         errors.push(`${prefix}: invalid border entry date`);
       }
@@ -300,7 +306,7 @@ export function validatePrecheckinPayload(
 export function precheckinWarnings(payload: PrecheckinPayload): string[] {
   const warnings: string[] = [];
   for (const traveler of payload.travelers) {
-    if (requiresNonEuBorderFields(traveler.citizenshipCountry)) {
+    if (requiresNonEuBorderFields(traveler.residenceCountry)) {
       if (!traveler.borderEntryDate || !traveler.borderEntryPlace || !traveler.borderEntryPoint) {
         warnings.push(`${traveler.firstName} ${traveler.lastName}: non-EU border data incomplete`);
       }

--- a/src/lib/request-path.test.ts
+++ b/src/lib/request-path.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { redactSensitiveRequestPath } from "@/lib/request-path";
+
+describe("request-path logging", () => {
+  it("redacts guest bearer tokens but preserves route shape", () => {
+    expect(redactSensitiveRequestPath("/g/super-secret-token"))
+      .toBe("/g/[redacted]");
+    expect(redactSensitiveRequestPath("/api/g/super-secret-token/draft"))
+      .toBe("/api/g/[redacted]/draft");
+  });
+
+  it("does not alter ordinary routes", () => {
+    expect(redactSensitiveRequestPath("/dashboard")).toBe("/dashboard");
+  });
+});

--- a/src/lib/request-path.ts
+++ b/src/lib/request-path.ts
@@ -1,0 +1,6 @@
+/** Remove bearer-style guest-form tokens before a path reaches normal logs. */
+export function redactSensitiveRequestPath(pathname: string): string {
+  return pathname
+    .replace(/^\/g\/[^/]+(?=\/|$)/, "/g/[redacted]")
+    .replace(/^\/api\/g\/[^/]+(?=\/|$)/, "/api/g/[redacted]");
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -51,6 +51,8 @@ export interface Reservation {
    *  personal-chat WhatsApp / Telegram quick-buttons even on bookings
    *  with no passport guests. */
   phone?: string | null;
+  /** Confirmed number of travelers in this booking. */
+  bookedGuestCount?: number | null;
   propertyId: number;
   createdAt: string;
   guests?: Guest[];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { jwtVerify } from "jose";
 import { log } from "@/lib/logger";
+import { redactSensitiveRequestPath } from "@/lib/request-path";
 
 const JWT_SECRET_RAW = process.env.JWT_SECRET || "fallback-secret-change-me";
 const SECRET = new TextEncoder().encode(JWT_SECRET_RAW);
@@ -105,7 +106,7 @@ function logRequest(
   log({
     msg: "http",
     method: request.method,
-    path: request.nextUrl.pathname,
+    path: redactSensitiveRequestPath(request.nextUrl.pathname),
     status: response.status,
     durationMs: Date.now() - startedAt,
     userId: userId ?? null,


### PR DESCRIPTION
## What this changes

- turns the existing pre-arrival form into one channel-neutral, reservation-bound flow for multiple travelers
- captures validated eVisitor-ready identity, residence, document, arrival and tax-category suggestion fields
- encrypts guest payloads and issued raw tokens at rest with a dedicated key
- hashes public tokens for lookup; adds expiry, revocation, autosaved encrypted drafts and owner review/approval states
- blocks cleaner and support-impersonation access to identity payloads
- removes guest names from outgoing iCal event titles and redacts guest tokens from application request logs
- blocks productive identity-data collection until the property calendar feeds have been token-protected
- keeps OCR out of the guest form and implements no eVisitor submission

## Safety boundaries

- no live portal, calendar, DNS or eVisitor changes
- no credentials or guest PII in the PR
- owner approval ends at `OWNER_APPROVED`; there is no `EVISITOR_SUBMITTED` runtime path
- existing public calendar feeds are not rotated automatically because that would invalidate connected portal URLs

## Verification

- `npm test`: 301 passed
- production build with an isolated SQLite test database: passed
- schema push against an empty isolated SQLite database: passed
- changed security/form files lint with ESLint 9: passed
- `git diff --check`: passed

## Known deployment gates

1. configure a distinct `GUEST_DATA_ENCRYPTION_KEY` in the deployment secret manager
2. back up the production database and run the additive schema push
3. rotate the property feed token and replace every connected portal feed URL in one controlled cutover
4. only then generate the first guest link
5. complete mobile/browser acceptance and a small owner-supervised pilot before production use

No merge requested; Owner decision required.